### PR TITLE
An implementation of the Speech Commands (v0.02) dataset

### DIFF
--- a/docs/src/python/common_datasets.rst
+++ b/docs/src/python/common_datasets.rst
@@ -66,3 +66,4 @@ the wikitext-103 datasets.
     load_imagenet
     load_librispeech
     load_wikitext_lines
+    load_speechcommands

--- a/python/mlx/data/datasets/__init__.py
+++ b/python/mlx/data/datasets/__init__.py
@@ -5,3 +5,4 @@ from .cifar import load_cifar10, load_cifar100
 from .librispeech import load_librispeech, load_librispeech_tarfile
 from .imagenet import load_imagenet, load_imagenet_metadata
 from .wikitext import load_wikitext_lines
+from .speechcommands import load_speechcommands

--- a/python/mlx/data/datasets/speechcommands.py
+++ b/python/mlx/data/datasets/speechcommands.py
@@ -1,0 +1,129 @@
+import hashlib
+import tarfile
+from pathlib import Path
+from ... import data as dx
+from .common import (
+    CACHE_DIR,
+    ensure_exists,
+    urlretrieve_with_progress,
+    file_digest,
+    gzip_decompress,
+)
+
+URL = "http://download.tensorflow.org/data/speech_commands_v0.02.tar.gz"
+URL_HASH = "af14739ee7dc311471de98f5f9d2c9191b18aedfe957f4a6ff791c709868ff58"
+
+SPLITS_INFO = {
+    "validation": "./validation_list.txt",
+    "test": "./testing_list.txt",
+    "train": None,
+}
+
+
+def download_speechcommands(root=None, quiet=False, validate_download=True):
+    """Download/fetch the speechcommands TAR archive and return the path to it for processing.
+
+    Args:
+        root (Path or str, optional): The The directory to load/save the data. If
+            none is given the ``~/.cache/mlx.data/speechcommands`` is used.
+        quiet (bool, optional): If true do not show download (and possibly decompression)
+            progress. Default is False.
+        validate_download (bool, optional): Validate the download using the checksum.
+            Default is True.
+    """
+    if root is None:
+        root = CACHE_DIR / "speechcommands"
+    else:
+        root = Path(root)
+    ensure_exists(root)
+    url, target_hash = URL, URL_HASH
+    filename = Path(url).name
+    target_compressed = root / filename
+    target = root / filename.replace(".gz", "")
+    if not target.is_file():
+        if not target_compressed.is_file():
+            urlretrieve_with_progress(url, target_compressed, quiet=quiet)
+            if validate_download:
+                h = file_digest(target_compressed, hashlib.sha256(), quiet=quiet)
+                if h.hexdigest() != target_hash:
+                    raise RuntimeError(
+                        f"[speechcommands] File download corrupted. sha256sums don't match. Please manually delete {str(target_compressed)}."
+                    )
+        gzip_decompress(target_compressed, target, quiet=quiet)
+        target_compressed.unlink()
+    return target
+
+
+def get_metadata(tarfile_path):
+    """
+    Helper function to get metadata from the tarfile.
+    This includes file names by split, as well as class names and their mapping to integers.
+    """
+    output = {}
+    with tarfile.open(tarfile_path) as tar:
+        for split, split_file in SPLITS_INFO.items():
+            if split_file is None:
+                continue
+            f = tar.extractfile(split_file)
+            fileslist = ["./" + s.decode().strip() for s in f.readlines()]
+            output[split] = fileslist
+
+        all_wav_files = [f.name for f in tar.getmembers() if ".wav" in f.name]
+    output["train"] = set(all_wav_files) - set(output["validation"] + output["test"])
+    classes = dict(
+        map(reversed, enumerate(sorted(set(f.split("/")[-2] for f in output["train"]))))
+    )
+    return output, classes
+
+
+def _to_audio(sample):
+    filename = bytes(sample["file"]).decode()
+    label = bytes(filename.split("/")[-2].encode())
+    return {"file": sample["file"], "audio": sample["audio"], "label": label}
+
+
+def load_speechcommands(
+    root=None,
+    split="train",
+    quiet=False,
+    validate_download=True,
+    prefetch_size=8,
+    num_threads=4,
+):
+    """Load the Speech Commands (v0.0.2) dataset directly from the TAR archive.
+
+    Args:
+        root (Path or str, optional): The The directory to load/save the data. If
+            none is given the ``~/.cache/mlx.data/speechcommands`` is used.
+        split (str): The split to use. It should be one of train,
+            validation or test
+        quiet (bool): If true do not show download (and possibly decompression)
+            progress.
+        prefetch_size (int, optional): The number of samples for prefetching. Default is 8.
+        num_threads (int, optional): The number of threads to use for prefetching. Default is 4.
+    """
+    target = download_speechcommands(
+        root=root, quiet=quiet, validate_download=validate_download
+    )
+    target = str(target)
+    assert (
+        split in SPLITS_INFO
+    ), f"Unknown split {split}. Should be one of [{', '.join(SPLITS_INFO.keys())}]"
+
+    files_by_split, class_map = get_metadata(target)
+
+    dset = (
+        dx.files_from_tar(target)
+        .to_stream()
+        .sample_transform(
+            lambda s: s
+            if bytes(s["file"]).decode() in files_by_split[split]
+            else dict()
+        )
+        .read_from_tar(target, "file", "audio")
+        .sample_transform(_to_audio)
+        .prefetch(prefetch_size, num_threads)
+        .load_audio("audio", from_memory=True)
+        .key_transform("label", lambda x: class_map[bytes(x).decode()])
+    )
+    return dset

--- a/python/mlx/data/datasets/speechcommands.py
+++ b/python/mlx/data/datasets/speechcommands.py
@@ -12,6 +12,8 @@ from .common import (
 
 URL = "http://download.tensorflow.org/data/speech_commands_v0.02.tar.gz"
 URL_HASH = "af14739ee7dc311471de98f5f9d2c9191b18aedfe957f4a6ff791c709868ff58"
+EXCLUDE_FOLDER = "_background_noise_"
+HASH_DIVIDER = "_nohash_"
 
 SPLITS_INFO = {
     "validation": "./validation_list.txt",
@@ -68,7 +70,13 @@ def get_metadata(tarfile_path):
             fileslist = ["./" + s.decode().strip() for s in f.readlines()]
             output[split] = fileslist
 
-        all_wav_files = [f.name for f in tar.getmembers() if ".wav" in f.name]
+        all_wav_files = [
+            f.name
+            for f in tar.getmembers()
+            if ".wav" in f.name
+            and HASH_DIVIDER in f.name
+            and EXCLUDE_FOLDER not in f.name
+        ]
     output["train"] = set(all_wav_files) - set(output["validation"] + output["test"])
     classes = dict(
         map(reversed, enumerate(sorted(set(f.split("/")[-2] for f in output["train"]))))

--- a/python/mlx/data/datasets/speechcommands.py
+++ b/python/mlx/data/datasets/speechcommands.py
@@ -98,7 +98,7 @@ def load_speechcommands(
     prefetch_size=8,
     num_threads=4,
 ):
-    """Load the Speech Commands (v0.0.2) dataset directly from the TAR archive.
+    """Load the Speech Commands (v0.0.2) [1] dataset directly from the TAR archive.
 
     Args:
         root (Path or str, optional): The The directory to load/save the data. If
@@ -109,6 +109,11 @@ def load_speechcommands(
             progress.
         prefetch_size (int, optional): The number of samples for prefetching. Default is 8.
         num_threads (int, optional): The number of threads to use for prefetching. Default is 4.
+
+
+    References
+    ----------
+    Warden, Pete. "Speech commands: A dataset for limited-vocabulary speech recognition." arXiv preprint arXiv:1804.03209 (2018).
     """
     target = download_speechcommands(
         root=root, quiet=quiet, validate_download=validate_download

--- a/python/mlx/data/datasets/speechcommands.py
+++ b/python/mlx/data/datasets/speechcommands.py
@@ -136,6 +136,7 @@ def load_speechcommands(
         .read_from_tar(target, "file", "audio")
         .sample_transform(_to_audio)
         .prefetch(prefetch_size, num_threads)
+        .to_buffer()
         .load_audio("audio", from_memory=True)
         .key_transform("label", lambda x: class_map[bytes(x).decode()])
     )

--- a/python/mlx/data/datasets/speechcommands.py
+++ b/python/mlx/data/datasets/speechcommands.py
@@ -84,20 +84,7 @@ def get_metadata(tarfile_path):
     return output, classes
 
 
-def _to_audio(sample):
-    filename = bytes(sample["file"]).decode()
-    label = bytes(filename.split("/")[-2].encode())
-    return {"file": sample["file"], "audio": sample["audio"], "label": label}
-
-
-def load_speechcommands(
-    root=None,
-    split="train",
-    quiet=False,
-    validate_download=True,
-    prefetch_size=8,
-    num_threads=4,
-):
+def load_speechcommands(root=None, split="train", quiet=False, validate_download=True):
     """Load the Speech Commands (v0.0.2) [1] dataset directly from the TAR archive.
 
     Args:
@@ -107,9 +94,6 @@ def load_speechcommands(
             validation or test
         quiet (bool): If true do not show download (and possibly decompression)
             progress.
-        prefetch_size (int, optional): The number of samples for prefetching. Default is 8.
-        num_threads (int, optional): The number of threads to use for prefetching. Default is 4.
-
 
     References
     ----------


### PR DESCRIPTION
This PR adds the Speech Commands (v0.02) dataset. I've used the existing `librispeech` implementation as a reference for the dataset, reading directly from the tar archive!

While an example for an audio dataset already exists (`librispeech`), I feel Speech Commands is a popular dataset that's also often used as a proof of concept by the speech/audio community, and might be handy for people taking `mlx-data` for a spin considering the small footprint (~2 GB). 