### PR TITLE
support negative indexing of buffers

### DIFF
--- a/mlx/data/buffer/FromVector.cpp
+++ b/mlx/data/buffer/FromVector.cpp
@@ -16,7 +16,7 @@ FromVector::FromVector(std::vector<Sample>&& data) : buffer_(std::move(data)) {
 
 Sample FromVector::get(int64_t idx) const {
   if (idx < 0 || idx >= buffer_.size()) {
-    throw std::runtime_error("FromVector: index out of range");
+    throw std::out_of_range("FromVector: index out of range");
   }
   return buffer_[idx];
 }

--- a/python/src/wrap_buffer.cpp
+++ b/python/src/wrap_buffer.cpp
@@ -59,6 +59,7 @@ void init_mlx_data_buffer(py::module& m) {
                 Sample sample;
                 {
                   py::gil_scoped_release release;
+                  idx = (idx < 0) ? idx + b.size() : idx;
                   sample = b.get(idx);
                 }
                 py::dict pysample;

--- a/python/tests/test_buffer.py
+++ b/python/tests/test_buffer.py
@@ -1,0 +1,20 @@
+# Copyright © 2024 Apple Inc.
+
+from unittest import TestCase
+
+import mlx.data as dx
+
+
+class TestBuffer(TestCase):
+    def test__getitem__(self):
+        n = 5
+        b = dx.buffer_from_vector(list(dict(i=i) for i in range(n)))
+        for i in range(n):
+            self.assertEqual(b[i]["i"], i)
+            i += 1
+            self.assertEqual(b[-i], b[n - i])
+
+        with self.assertRaises(IndexError):
+            _ = b[n]
+        with self.assertRaises(IndexError):
+            _ = b[-(n + 1)]


### PR DESCRIPTION
The __getitem__ method now accepts both positive and negative indices. Overflow issues are appropriately handled as out_of_range/IndexError, maintaining consistency with mx.array and other containers.

Additionally, an initial Python unit test has been included to kickstart the testing process.

Closes #18

Running tests from circleci is still missing, but that is hard to do from a fork (at least I don't know how). I personally just have experience with GH workflows. 