### PR TITLE
Fix benchmark and occasional bus error

### DIFF
--- a/benchmarks/comparative/librispeech/mlx_data.py
+++ b/benchmarks/comparative/librispeech/mlx_data.py
@@ -45,12 +45,12 @@ def iterate(args, workers):
         .load_audio("audio", prefix=args.data_dir)
         .squeeze("audio")
         .key_transform("audio", mfsc(128, 16000))
-        .shape("audio", 0, "audio_length")
+        .shape("audio", "audio_length", 0)
         # Tokenize the transcript
         .tokenize("transcript", trie)
         .pad("transcript", 0, 1, 0, trie.search("<s>").id)
         .pad("transcript", 0, 0, 1, trie.search("</s>").id)
-        .shape("transcript", 0, "transcript_length")
+        .shape("transcript", "transcript_length", 0)
         # Batch and prefetch
         .batch(args.batch_size)
         .prefetch(workers, workers)

--- a/python/mlx/data/__init__.py
+++ b/python/mlx/data/__init__.py
@@ -1,4 +1,13 @@
 # Copyright © 2023 Apple Inc.
 
+
 from ._c import *
 from ._c import __version__
+
+# fmt: off
+# Passing strings from python to be casted by pybind11 crashes on some builds
+# if we don't import numpy.
+#
+# TODO: Evaluate if it is due to improper linking and fix correctly.
+import numpy  # isort: skip
+del numpy


### PR DESCRIPTION
The comment in the fix explains it all. Basically for some static builds there is a bus error if numpy is not imported and pybind11 has to cast to numpy.