### PR TITLE
Add Fashion-MNIST dataset

### DIFF
--- a/docs/src/python/common_datasets.rst
+++ b/docs/src/python/common_datasets.rst
@@ -61,6 +61,7 @@ the wikitext-103 datasets.
    :toctree: _autosummary
 
     load_mnist
+    load_fashion_mnist
     load_cifar10
     load_cifar100
     load_imagenet

--- a/python/mlx/data/datasets/__init__.py
+++ b/python/mlx/data/datasets/__init__.py
@@ -4,6 +4,6 @@ from .cifar import load_cifar10, load_cifar100
 from .image_folder import load_images_from_folder
 from .imagenet import load_imagenet, load_imagenet_metadata
 from .librispeech import load_librispeech, load_librispeech_tarfile
-from .mnist import load_mnist
+from .mnist import load_fashion_mnist, load_mnist
 from .speechcommands import load_speechcommands
 from .wikitext import load_wikitext_lines

--- a/python/mlx/data/datasets/mnist.py
+++ b/python/mlx/data/datasets/mnist.py
@@ -11,25 +11,21 @@ from ... import data as dx
 from .common import CACHE_DIR, ensure_exists, urlretrieve_with_progress
 
 
-def load_mnist(root=None, train=True):
-    """Load a buffer with the MNIST dataset.
+def _load_mnist_wrapper(root=None, train=True, dataset="mnist"):
+    url_dict = {
+        "mnist": "http://yann.lecun.com/exdb/mnist/",
+        "fashion-mnist": "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/",
+    }
+    base_url = url_dict[dataset]
 
-    If the data doesn't exist download it and save it for the next time.
-
-    Args:
-        root (Path or str, optional): The directory to load/save the data. If
-            none is given the ``~/.cache/mlx.data/mnist`` is used.
-        train (bool): Load the training or test set.
-    """
     if root is None:
-        root = CACHE_DIR / "mnist"
+        root = CACHE_DIR / dataset
     else:
         root = Path(root)
 
     ensure_exists(root)
 
     def download():
-        base_url = "http://yann.lecun.com/exdb/mnist/"
         filename = [
             [NamedTemporaryFile(), "training_images", "train-images-idx3-ubyte.gz"],
             [NamedTemporaryFile(), "test_images", "t10k-images-idx3-ubyte.gz"],
@@ -69,3 +65,31 @@ def load_mnist(root=None, train=True):
     pkl_file = (root / "train.pkl") if train else (root / "test.pkl")
     with pkl_file.open("rb") as f:
         return dx.buffer_from_vector(pickle.load(f))
+
+
+def load_mnist(root=None, train=True):
+    """Load a buffer with the MNIST dataset.
+
+    If the data doesn't exist download it and save it for the next time.
+
+    Args:
+        root (Path or str, optional): The directory to load/save the data. If
+            none is given the ``~/.cache/mlx.data/mnist`` is used.
+        train (bool): Load the training or test set.
+    """
+
+    return _load_mnist_wrapper(root, train, "mnist")
+
+
+def load_fashion_mnist(root=None, train=True):
+    """Load a buffer with the Fashion-MNIST dataset.
+
+    If the data doesn't exist download it and save it for the next time.
+
+    Args:
+        root (Path or str, optional): The directory to load/save the data. If
+            none is given the ``~/.cache/mlx.data/fashion-mnist`` is used.
+        train (bool): Load the training or test set.
+    """
+
+    return _load_mnist_wrapper(root, train, "fashion-mnist")


### PR DESCRIPTION
This adds Fashion-MNIST, which is a drop-in replacement for the original MNIST dataset.