### PR TITLE
Stream | sliding window: add storing of slice index into sample

### DIFF
--- a/mlx/data/Stream.cpp
+++ b/mlx/data/Stream.cpp
@@ -137,9 +137,10 @@ Stream Stream::sliding_window(
     const std::string& key,
     int64_t size,
     int64_t stride,
-    int dim) const {
-  return Stream(
-      std::make_shared<stream::SlidingWindow>(self_, key, size, stride, dim));
+    int dim,
+    const std::string& indexKey) const {
+  return Stream(std::make_shared<stream::SlidingWindow>(
+      self_, key, size, stride, dim, indexKey));
 }
 
 Buffer Stream::to_buffer() {

--- a/mlx/data/Stream.h
+++ b/mlx/data/Stream.h
@@ -69,7 +69,8 @@ class Stream : public Dataset<Stream, stream::Stream> {
       const std::string& key,
       int64_t size,
       int64_t stride,
-      int dim = -1) const;
+      int dim = -1,
+      const std::string& indexKey = "") const;
 
   Buffer to_buffer();
 };

--- a/mlx/data/stream/SlidingWindow.h
+++ b/mlx/data/stream/SlidingWindow.h
@@ -18,7 +18,8 @@ class SlidingWindow : public Stream {
       const std::string& key,
       int64_t size,
       int64_t stride,
-      int dim = -1);
+      int dim = -1,
+      const std::string& indexKey = "");
 
   virtual Sample next() const override;
   virtual void reset() override;
@@ -31,6 +32,7 @@ class SlidingWindow : public Stream {
   int64_t size_;
   int64_t stride_;
   int dim_;
+  const std::string& indexKey_;
 };
 
 } // namespace stream

--- a/mlx/data/stream/SlidingWindow.h
+++ b/mlx/data/stream/SlidingWindow.h
@@ -32,7 +32,7 @@ class SlidingWindow : public Stream {
   int64_t size_;
   int64_t stride_;
   int dim_;
-  const std::string& indexKey_;
+  std::string& indexKey_;
 };
 
 } // namespace stream

--- a/python/src/wrap_stream.cpp
+++ b/python/src/wrap_stream.cpp
@@ -385,6 +385,7 @@ void init_mlx_data_stream(py::module& m) {
               py::arg("size"),
               py::arg("stride"),
               py::arg("dim") = -1,
+              py::arg("index_key") = "",
               R"pbcopy(
                 Creates sample by sliding a window over the array at ``key``.
 
@@ -409,9 +410,10 @@ void init_mlx_data_stream(py::module& m) {
 
                 Args:
                   key (str): The sample key that contains the array we are operating on.
-                  size (int): The size of the sliding window
-                  stride (int): The stride of the sliding window
+                  size (int): The size of the sliding window.
+                  stride (int): The stride of the sliding window.
                   dim (int): Which dimension are we sliding the window over. (default: -1)
+                  index_key (str): The sample key where sliding window index will be stored. If string is empty key will not be added. (default: "")
               )pbcopy")
           .def(
               "to_buffer",


### PR DESCRIPTION
In the call of sliding window operation we add support of storing index of the slice into new key in the sample to be able to reconstruct the order of the slices later. The use-case is e.g. audio segments in data processing.