### PR TITLE
Improves AWSFileFetcher

### DIFF
--- a/mlx/data/core/AWSFileFetcher.cpp
+++ b/mlx/data/core/AWSFileFetcher.cpp
@@ -135,21 +135,22 @@ int64_t AWSFileFetcher::get_size(const std::string& filename) const {
 }
 
 void AWSFileFetcher::backend_fetch(const std::string& filename) const {
-  auto size = get_size(filename);
-  auto numPart = size / buffer_size_;
-  if (size % buffer_size_) {
-    numPart++;
-  }
+  // Do not fetch a file already present on disk
   auto remoteFilePath = (prefix_ / filename);
   auto localFilePath = (local_prefix_ / filename);
   if (std::filesystem::exists(localFilePath)) {
     if (verbose_) {
       std::cout << "AWSFileFetcher (" << std::hex << this << std::dec
-                << ") : file s3://" << bucket_ << "/" << remoteFilePath << " ("
-                << size << " bytes) already exists in " << localFilePath
-                << std::endl;
+                << ") : file s3://" << bucket_ << "/" << remoteFilePath
+                << " already exists in " << localFilePath << std::endl;
     }
     return;
+  }
+
+  auto size = get_size(filename);
+  auto numPart = size / buffer_size_;
+  if (size % buffer_size_) {
+    numPart++;
   }
   if (verbose_) {
     std::cout << "AWSFileFetcher (" << std::hex << this << std::dec

--- a/mlx/data/core/AWSFileFetcher.cpp
+++ b/mlx/data/core/AWSFileFetcher.cpp
@@ -128,8 +128,9 @@ int64_t AWSFileFetcher::get_size(const std::string& filename) const {
   } else {
     const Aws::S3::S3Error& err = outcome.GetError();
     throw std::runtime_error(
-        "AWSFileFetcher: unable to fetch <" + remote_file_path.string() +
-        "> header: " + err.GetExceptionName() + " : " + err.GetMessage());
+        "AWSFileFetcher: unable to fetch <s3://" + bucket_ + "/" +
+        remote_file_path.string() + "> header: " + err.GetExceptionName() +
+        " : " + err.GetMessage());
   }
 }
 
@@ -143,8 +144,8 @@ void AWSFileFetcher::backend_fetch(const std::string& filename) const {
   auto localFilePath = (local_prefix_ / filename);
   if (verbose_) {
     std::cout << "AWSFileFetcher (" << std::hex << this << std::dec
-              << ") : fetching " << remoteFilePath << " (" << size
-              << " bytes) into " << localFilePath << std::endl;
+              << ") : fetching s3://" << bucket_ << "/" << remoteFilePath
+              << " (" << size << " bytes) into " << localFilePath << std::endl;
   }
 
   // Note: the threads might fetch data faster than what
@@ -213,8 +214,9 @@ void AWSFileFetcher::backend_fetch(const std::string& filename) const {
     if (!outcome.IsSuccess()) {
       const Aws::S3::S3Error& err = outcome.GetError();
       throw std::runtime_error(
-          "AWSFileFetcher: unable to fetch <" + remoteFilePath.string() +
-          "> : " + err.GetExceptionName() + " : " + err.GetMessage());
+          "AWSFileFetcher: unable to fetch <s3://" + bucket_ + "/" +
+          remoteFilePath.string() + "> : " + err.GetExceptionName() + " : " +
+          err.GetMessage());
     } else {
       auto& buf = outcome.GetResult().GetBody();
       f << buf.rdbuf();
@@ -236,8 +238,9 @@ void AWSFileFetcher::backend_fetch(const std::string& filename) const {
   if (verbose_) {
     std::cout << "AWSFileFetcher (" << std::hex << this << std::dec
               << ") : " << (dtor_called_.load() ? "aborted" : "done")
-              << " fetching " << remoteFilePath << " (" << totalWrittenSize
-              << "/" << size << " bytes) into " << localFilePath << std::endl;
+              << " fetching s3://" << bucket_ << "/" << remoteFilePath << " ("
+              << totalWrittenSize << "/" << size << " bytes) into "
+              << localFilePath << std::endl;
   }
 }
 

--- a/mlx/data/core/AWSFileFetcher.cpp
+++ b/mlx/data/core/AWSFileFetcher.cpp
@@ -261,7 +261,12 @@ void AWSFileFetcher::backend_fetch(const std::string& filename) const {
 
 void AWSFileFetcher::backend_erase(const std::string& filename) const {
   auto localFilePath = (local_prefix_ / filename);
-  std::filesystem::remove(localFilePath);
+  auto status = std::filesystem::remove(localFilePath);
+  if (verbose_) {
+    std::cout << "AWSFileFetcher (" << std::hex << this << std::dec
+              << ") : erasing " << localFilePath
+              << (status ? " (done)" : " (file does not exist)") << std::endl;
+  }
 }
 
 AWSFileFetcher::~AWSFileFetcher() {

--- a/mlx/data/core/AWSFileFetcher.h
+++ b/mlx/data/core/AWSFileFetcher.h
@@ -99,7 +99,8 @@ class AWSFileFetcher : public FileFetcher {
       std::tuple<std::string, std::string, std::string, std::string>()>
       credentials_callback_;
   int64_t credentials_period_;
-  std::chrono::time_point<std::chrono::system_clock> credentials_timestamp_;
+  mutable std::chrono::time_point<std::chrono::system_clock>
+      credentials_timestamp_;
 };
 
 } // namespace core

--- a/mlx/data/core/AWSFileFetcher.h
+++ b/mlx/data/core/AWSFileFetcher.h
@@ -58,6 +58,12 @@ class AWSFileFetcher : public FileFetcher {
   virtual void backend_fetch(const std::string& filename) const override;
   virtual void backend_erase(const std::string& filename) const override;
 
+  void update_credentials(
+      const std::string& access_key_id = "",
+      const std::string secret_access_key = "",
+      const std::string session_token = "",
+      const std::string expiration = "") const;
+
   bool are_credentials_expired() const;
 
   virtual ~AWSFileFetcher();
@@ -67,11 +73,13 @@ class AWSFileFetcher : public FileFetcher {
   std::filesystem::path prefix_;
   std::filesystem::path local_prefix_;
   std::unique_ptr<Aws::Client::ClientConfiguration> config_;
-  std::unique_ptr<Aws::Auth::AWSCredentials> credentials_;
-  std::unique_ptr<Aws::S3::S3Client> client_;
+  bool config_virtual_host_;
   int64_t buffer_size_;
   int num_threads_;
+  mutable std::unique_ptr<Aws::Auth::AWSCredentials> credentials_;
+  mutable std::unique_ptr<Aws::S3::S3Client> client_;
   mutable std::atomic<bool> dtor_called_;
+  mutable std::shared_mutex client_mutex_;
 };
 
 } // namespace core

--- a/mlx/data/core/AWSFileFetcher.h
+++ b/mlx/data/core/AWSFileFetcher.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
 
 #include <aws/core/Aws.h>
@@ -75,12 +76,7 @@ class AWSFileFetcher : public FileFetcher {
   virtual ~AWSFileFetcher();
 
  protected:
-  void check_credentials_() const;
-  void update_credentials_(
-      const std::string& access_key_id,
-      const std::string& secret_access_key,
-      const std::string& session_token,
-      const std::string& expiration) const; // no lock;
+  void check_credentials() const;
 
   std::string bucket_;
   std::filesystem::path prefix_;
@@ -101,6 +97,7 @@ class AWSFileFetcher : public FileFetcher {
   int64_t credentials_period_;
   mutable std::chrono::time_point<std::chrono::system_clock>
       credentials_timestamp_;
+  mutable std::shared_mutex credentials_mutex_;
 };
 
 } // namespace core

--- a/mlx/data/core/FileFetcher.cpp
+++ b/mlx/data/core/FileFetcher.cpp
@@ -131,6 +131,12 @@ std::shared_ptr<FileFetcherHandle> FileFetcher::fetch(
   }
 }
 
+void FileFetcher::erase(const std::string& filename) const {
+  std::unique_lock ulock(mutex_);
+  cachedFiles_.erase(filename);
+  backend_erase(filename);
+}
+
 void FileFetcher::backend_fetch(const std::string& filename) const {}
 void FileFetcher::backend_erase(const std::string& filename) const {}
 

--- a/mlx/data/core/FileFetcher.h
+++ b/mlx/data/core/FileFetcher.h
@@ -48,6 +48,9 @@ class FileFetcher {
 
   std::shared_ptr<FileFetcherHandle> fetch(const std::string& filename) const;
 
+  // Erase a file from cache, and call backend erase
+  void erase(const std::string& filename) const;
+
   virtual void backend_fetch(const std::string& filename) const;
 
   virtual void backend_erase(const std::string& filename) const;

--- a/python/src/wrap_core.cpp
+++ b/python/src/wrap_core.cpp
@@ -314,6 +314,16 @@ void init_mlx_data_core(py::module& m) {
 
           Args:
             filename (str): A file to fetch from the remote.
+        )pbcopy")
+      .def(
+          "erase",
+          &FileFetcher::erase,
+          py::arg("filename"),
+          R"pbcopy(
+          Erase the filename from the local cache (if present).
+
+          Args:
+            filename (str): A file to fetch from the remote.
         )pbcopy");
 
 #if MLX_HAS_AWS

--- a/python/src/wrap_core.cpp
+++ b/python/src/wrap_core.cpp
@@ -323,7 +323,7 @@ void init_mlx_data_core(py::module& m) {
           Erase the filename from the local cache (if present).
 
           Args:
-            filename (str): A file to fetch from the remote.
+            filename (str): A file to erase locally.
         )pbcopy");
 
 #if MLX_HAS_AWS
@@ -435,6 +435,26 @@ void init_mlx_data_core(py::module& m) {
               verbose (bool): Defines whether the file fetcher should write
                 information messages to the standard output. (default: false)
           )pbcopy")
+      .def(
+          "update_credentials",
+          &AWSFileFetcher::update_credentials,
+          py::arg("access_key_id") = "",
+          py::arg("secret_access_key") = "",
+          py::arg("session_token") = "",
+          py::arg("expiration") = "",
+          R"pbcopy(
+          Update the AWSFileFetcher credentials.
+
+          Args:
+              access_key_id (str): Set the AWS access key id to authenticate to
+                the remote service. (default: '')
+              secret_access_key (str): Set the AWS secret access key id to
+                authenticate to the remote service. (default: '')
+              session_token (str): Set the AWS session token to authenticate to
+                the remote service. (default: '')
+              expiration (str): A date string defining the expiration of the
+                authentication credentials (default: '')
+        )pbcopy")
       .def("are_credentials_expired", &AWSFileFetcher::are_credentials_expired);
 
   AWSHandler::init();


### PR DESCRIPTION
- AWSFileFetcher will not download a file already present on local disk
- FileFetcher::erase(filename) erases filename from the cache / local disk
- AWSFileFetcher::update_credentials() updates the AWS S3 client with provided credentials
- AWSFileFetcher::update_credentials_with_callback() allows to update credentials via a callback...
   - when credentials are outdated
   - every given period of time
   
