### PR TITLE
Fix an edge case tokenizing with ignore unknown

### DIFF
--- a/mlx/data/core/Tokenizer.cpp
+++ b/mlx/data/core/Tokenizer.cpp
@@ -80,7 +80,12 @@ std::shared_ptr<Graph<int64_t>> tokenize(
 
   // note: only one hyp should have trie->root()
   if (std::get<0>(hyps.front()) != trie->root()) {
-    throw std::runtime_error("could not tokenize: <" + input + ">");
+    if (ignore_unk) {
+      // Use the last word hypothesis as the final node
+      hyps = {last_word_hyp};
+    } else {
+      throw std::runtime_error("could not tokenize: <" + input + ">");
+    }
   }
   tokens.final_node(std::get<1>(hyps.front()));
 


### PR DESCRIPTION
Previously the following code would fail to tokenize the 2nd string even though `ignore_unk` is set to True.

```python
import mlx.data.core
from mlx.data.core import CharTrie


if __name__ == "__main__":
    vocab = CharTrie()
    vocab.insert("hello")
    vocab.insert(" world")

    tokenizer = mlx.data.core.Tokenizer(vocab, ignore_unk=True)
    print(tokenizer.tokenize_shortest("hello world"))
    print(tokenizer.tokenize_shortest("hello "))
```