### PR TITLE
Add a replace operation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,8 @@ set(mlxdata-src
     ${CMAKE_CURRENT_LIST_DIR}/mlx/data/op/Squeeze.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mlx/data/op/Tokenize.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mlx/data/op/ImageTransform.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/mlx/data/op/RemoveValue.cpp)
+    ${CMAKE_CURRENT_LIST_DIR}/mlx/data/op/RemoveValue.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/mlx/data/op/Replace.cpp)
 
 if(AWSSDK_FOUND)
   list(APPEND mlxdata-src

--- a/mlx/data/Array.cpp
+++ b/mlx/data/Array.cpp
@@ -115,6 +115,11 @@ Array::Array(const std::string& str) {
   std::memcpy(data_.get(), str.data(), str.size());
 }
 
+Array::Array(std::string_view str) {
+  init_(ArrayType::Int8, {static_cast<int64_t>(str.size())});
+  std::memcpy(data_.get(), str.data(), str.size());
+}
+
 template <class T>
 void array_fill(void* data, int64_t size, double value) {
   auto data_t = reinterpret_cast<T*>(data);

--- a/mlx/data/Array.h
+++ b/mlx/data/Array.h
@@ -23,6 +23,7 @@ class Array {
   Array(const std::shared_ptr<const Array>& src);
   Array(ArrayType type);
   Array(const std::string& str);
+  Array(std::string_view str);
   Array(ArrayType type, const std::vector<int64_t>& shape);
   Array(
       ArrayType type,

--- a/mlx/data/Dataset.cpp
+++ b/mlx/data/Dataset.cpp
@@ -708,6 +708,29 @@ T Dataset<T, B>::replace_if(
 }
 
 template <class T, class B>
+T Dataset<T, B>::replace_bytes(
+    const std::string& ikey,
+    std::vector<std::string> byte_map,
+    const std::string& okey) {
+  return transform_(
+      std::make_shared<op::ReplaceBytes>(ikey, std::move(byte_map), okey));
+}
+
+template <class T, class B>
+T Dataset<T, B>::replace_bytes_if(
+    bool cond,
+    const std::string& ikey,
+    std::vector<std::string> byte_map,
+    const std::string& okey) {
+  if (cond) {
+    return transform_(
+        std::make_shared<op::ReplaceBytes>(ikey, std::move(byte_map), okey));
+  } else {
+    return T(self_);
+  }
+}
+
+template <class T, class B>
 T Dataset<T, B>::rename_key(const std::string& ikey, const std::string& okey)
     const {
   return transform_(std::make_shared<op::RenameKey>(ikey, okey));

--- a/mlx/data/Dataset.cpp
+++ b/mlx/data/Dataset.cpp
@@ -21,6 +21,7 @@
 #include "mlx/data/op/ReadFromTAR.h"
 #include "mlx/data/op/RemoveValue.h"
 #include "mlx/data/op/RenameKey.h"
+#include "mlx/data/op/Replace.h"
 #include "mlx/data/op/SampleTransform.h"
 #include "mlx/data/op/SaveImage.h"
 #include "mlx/data/op/Shape.h"
@@ -676,6 +677,31 @@ T Dataset<T, B>::remove_value_if(
   if (cond) {
     return transform_(
         std::make_shared<op::RemoveValue>(key, size_key, dim, value, pad));
+  } else {
+    return T(self_);
+  }
+}
+
+template <class T, class B>
+T Dataset<T, B>::replace(
+    const std::string& key,
+    const std::string& old,
+    const std::string& replacement,
+    int count) {
+  return transform_(
+      std::make_shared<op::Replace>(key, old, replacement, count));
+}
+
+template <class T, class B>
+T Dataset<T, B>::replace_if(
+    bool cond,
+    const std::string& key,
+    const std::string& old,
+    const std::string& replacement,
+    int count) {
+  if (cond) {
+    return transform_(
+        std::make_shared<op::Replace>(key, old, replacement, count));
   } else {
     return T(self_);
   }

--- a/mlx/data/Dataset.h
+++ b/mlx/data/Dataset.h
@@ -337,6 +337,18 @@ class Dataset {
       double value,
       double pad) const;
 
+  T replace(
+      const std::string& key,
+      const std::string& old,
+      const std::string& replacement,
+      int count = -1);
+  T replace_if(
+      bool cond,
+      const std::string& key,
+      const std::string& old,
+      const std::string& replacement,
+      int count = -1);
+
   T rename_key(const std::string& ikey, const std::string& okey) const;
   T rename_key_if(bool cond, const std::string& ikey, const std::string& okey)
       const;

--- a/mlx/data/Dataset.h
+++ b/mlx/data/Dataset.h
@@ -349,6 +349,16 @@ class Dataset {
       const std::string& replacement,
       int count = -1);
 
+  T replace_bytes(
+      const std::string& ikey,
+      std::vector<std::string> byte_map,
+      const std::string& okey = "");
+  T replace_bytes_if(
+      bool cond,
+      const std::string& ikey,
+      std::vector<std::string> byte_map,
+      const std::string& okey = "");
+
   T rename_key(const std::string& ikey, const std::string& okey) const;
   T rename_key_if(bool cond, const std::string& ikey, const std::string& okey)
       const;

--- a/mlx/data/core/Utils.cpp
+++ b/mlx/data/core/Utils.cpp
@@ -106,9 +106,9 @@ void remove_t(
 template <typename T>
 void replace_t(
     std::shared_ptr<Array>& result,
-    const std::shared_ptr<Array> src,
-    const std::shared_ptr<Array> old,
-    const std::shared_ptr<Array> replacement,
+    const std::shared_ptr<const Array>& src,
+    const std::shared_ptr<const Array>& old,
+    const std::shared_ptr<const Array>& replacement,
     int count) {
   int64_t src_size = src->size();
   int64_t old_size = old->size();
@@ -252,9 +252,9 @@ Sample merge_batch(
 }
 
 std::shared_ptr<Array> replace(
-    const std::shared_ptr<Array> src,
-    const std::shared_ptr<Array> old,
-    const std::shared_ptr<Array> replacement,
+    const std::shared_ptr<const Array>& src,
+    const std::shared_ptr<const Array>& old,
+    const std::shared_ptr<const Array>& replacement,
     int count) {
   std::shared_ptr<Array> result;
   ARRAY_DISPATCH(src, replace_t, result, src, old, replacement, count);

--- a/mlx/data/core/Utils.h
+++ b/mlx/data/core/Utils.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Apple Inc.
+// Copyright © 2023-2024 Apple Inc.
 
 #include "mlx/data/Array.h"
 #include "mlx/data/Sample.h"
@@ -19,6 +19,12 @@ std::pair<std::shared_ptr<Array>, std::shared_ptr<Array>> remove(
     int dim,
     double value,
     double pad);
+
+std::shared_ptr<Array> replace(
+    const std::shared_ptr<Array> src,
+    const std::shared_ptr<Array> old,
+    const std::shared_ptr<Array> replacement,
+    int count);
 
 Sample merge_batch(
     const std::vector<Sample>& samples,

--- a/mlx/data/core/Utils.h
+++ b/mlx/data/core/Utils.h
@@ -21,9 +21,9 @@ std::pair<std::shared_ptr<Array>, std::shared_ptr<Array>> remove(
     double pad);
 
 std::shared_ptr<Array> replace(
-    const std::shared_ptr<Array> src,
-    const std::shared_ptr<Array> old,
-    const std::shared_ptr<Array> replacement,
+    const std::shared_ptr<const Array>& src,
+    const std::shared_ptr<const Array>& old,
+    const std::shared_ptr<const Array>& replacement,
     int count);
 
 Sample merge_batch(

--- a/mlx/data/op/Replace.cpp
+++ b/mlx/data/op/Replace.cpp
@@ -1,0 +1,30 @@
+// Copyright © 2024 Apple Inc.
+
+#include "mlx/data/op/Replace.h"
+#include "mlx/data/core/Utils.h"
+
+namespace mlx {
+namespace data {
+namespace op {
+
+Replace::Replace(
+    const std::string& key,
+    const std::string& old,
+    const std::string& replacement,
+    int count)
+    : key_(key),
+      old_(std::make_shared<Array>(old)),
+      replacement_(std::make_shared<Array>(replacement)),
+      count_(count) {}
+
+Sample Replace::apply(const Sample& sample) const {
+  auto value = sample::check_key(sample, key_, old_->type());
+  value = core::replace(value, old_, replacement_, count_);
+  auto new_sample = sample;
+  new_sample[key_] = value;
+  return new_sample;
+}
+
+} // namespace op
+} // namespace data
+} // namespace mlx

--- a/mlx/data/op/Replace.h
+++ b/mlx/data/op/Replace.h
@@ -1,0 +1,30 @@
+// Copyright © 2024 Apple Inc.
+
+#pragma once
+
+#include "mlx/data/op/Op.h"
+
+namespace mlx {
+namespace data {
+namespace op {
+
+class Replace : public Op {
+ public:
+  Replace(
+      const std::string& key,
+      const std::string& old,
+      const std::string& replacement,
+      int count);
+
+  virtual Sample apply(const Sample& sample) const override;
+
+ private:
+  std::string key_;
+  std::shared_ptr<Array> old_;
+  std::shared_ptr<Array> replacement_;
+  int count_;
+};
+
+} // namespace op
+} // namespace data
+} // namespace mlx

--- a/mlx/data/op/Replace.h
+++ b/mlx/data/op/Replace.h
@@ -2,13 +2,15 @@
 
 #pragma once
 
-#include "mlx/data/op/Op.h"
+#include <vector>
+
+#include "mlx/data/op/KeyTransform.h"
 
 namespace mlx {
 namespace data {
 namespace op {
 
-class Replace : public Op {
+class Replace : public KeyTransformOp {
  public:
   Replace(
       const std::string& key,
@@ -16,13 +18,28 @@ class Replace : public Op {
       const std::string& replacement,
       int count);
 
-  virtual Sample apply(const Sample& sample) const override;
+  virtual std::shared_ptr<Array> apply_key(
+      const std::shared_ptr<const Array>& src) const override;
 
  private:
   std::string key_;
   std::shared_ptr<Array> old_;
   std::shared_ptr<Array> replacement_;
   int count_;
+};
+
+class ReplaceBytes : public KeyTransformOp {
+ public:
+  ReplaceBytes(
+      const std::string& ikey,
+      std::vector<std::string> byte_map,
+      const std::string& okey = "");
+
+  virtual std::shared_ptr<Array> apply_key(
+      const std::shared_ptr<const Array>& src) const override;
+
+ private:
+  std::vector<std::string> byte_map_;
 };
 
 } // namespace op

--- a/python/src/wrap_dataset.h
+++ b/python/src/wrap_dataset.h
@@ -1004,6 +1004,42 @@ void mlx_data_export_dataset(py::class_<T, P>& base) {
       "Conditional :meth:`Buffer.remove_value`.");
 
   base.def(
+      "replace",
+      &T::replace,
+      py::call_guard<py::gil_scoped_release>(),
+      py::arg("key"),
+      py::arg("old"),
+      py::arg("replacement"),
+      py::arg("count") = -1,
+      R"pbdoc(
+        Replace ``old`` with ``replacement`` in the array at  ``key``.
+
+        Example:
+
+        .. code-block:: python
+
+          # Replace ' ' with '▁' to prepare for SPM tokenization.
+          dset = dset.replace("text", " ", "\u2581")
+
+        Args:
+          key (str): The sample key that contains the array we are operating on.
+          old (str): The character sequence that we are replacing.
+          replacement (str): The character sequence that we are replacing with.
+          count (int): Perform at most ``count`` replacements. Ignore if negative.
+              Default: ``-1``.
+      )pbdoc");
+  base.def(
+      "replace_if",
+      &T::replace_if,
+      py::call_guard<py::gil_scoped_release>(),
+      py::arg("cond"),
+      py::arg("key"),
+      py::arg("old"),
+      py::arg("replacement"),
+      py::arg("count") = -1,
+      "Conditional :meth:`Buffer.replace`.");
+
+  base.def(
       "rename_key",
       &T::rename_key,
       py::call_guard<py::gil_scoped_release>(),

--- a/python/src/wrap_dataset.h
+++ b/python/src/wrap_dataset.h
@@ -1040,6 +1040,35 @@ void mlx_data_export_dataset(py::class_<T, P>& base) {
       "Conditional :meth:`Buffer.replace`.");
 
   base.def(
+      "replace_bytes",
+      &T::replace_bytes,
+      py::call_guard<py::gil_scoped_release>(),
+      py::arg("ikey"),
+      py::arg("byte_map"),
+      py::arg("output_key") = "",
+      R"pbdoc(
+        Replace the bytes at ``key`` using the provided ``byte_map``.
+
+        A byte can map to any string. If an array is not a byte type it will be
+        reinterpreted as a byte array and remapped.
+
+        Args:
+          ikey (str): The sample key that contains the array we are operating on.
+          byte_map (list of str): A list of 256 strings that each byte maps to
+          output_key (str): If it is not empty then write the result to this
+            key instead of overwriting ``key``. (default: '')
+      )pbdoc");
+  base.def(
+      "replace_bytes_if",
+      &T::replace_bytes_if,
+      py::call_guard<py::gil_scoped_release>(),
+      py::arg("cond"),
+      py::arg("ikey"),
+      py::arg("byte_map"),
+      py::arg("output_key") = "",
+      "Conditional :meth:`Buffer.replace_bytes`.");
+
+  base.def(
       "rename_key",
       &T::rename_key,
       py::call_guard<py::gil_scoped_release>(),

--- a/python/tests/test_replace.py
+++ b/python/tests/test_replace.py
@@ -1,0 +1,24 @@
+# Copyright © 2024 Apple Inc.
+
+import unittest
+
+import mlx.data as dx
+
+
+class TestReplace(unittest.TestCase):
+    def test_replace(self):
+        s = "Hello world".encode()
+        dset = dx.buffer_from_vector([dict(text=s)])
+
+        ds = dset.replace("text", "world", "everybody!")
+        self.assertEqual(bytes(ds[0]["text"]), b"Hello everybody!")
+
+        ds = dset.replace("text", "l", "b")
+        self.assertEqual(bytes(ds[0]["text"]), b"Hebbo worbd")
+
+        ds = dset.replace("text", "l", "b", 2)
+        self.assertEqual(bytes(ds[0]["text"]), b"Hebbo world")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Like the tests, it enables replacing array subsequences with other array subsequences. The resulting array is flattened regardless of the original number of dimensions. Although any type is supported, only int8 arrays are exposed for string replacement.

The subsequence search code is not optimal but it is pretty fast so we could optimize if it becomes a bottleneck.