### PR TITLE
Add BPE tokenizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ set(mlxdata-src
     ${CMAKE_CURRENT_LIST_DIR}/mlx/data/core/ThreadController.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mlx/data/core/ThreadPool.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mlx/data/core/Tokenizer.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/mlx/data/core/BPETokenizer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mlx/data/core/Levenshtein.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mlx/data/core/Utils.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mlx/data/core/audio/Audio.cpp

--- a/mlx/data/Dataset.cpp
+++ b/mlx/data/Dataset.cpp
@@ -974,37 +974,25 @@ T Dataset<T, B>::tokenize_if(
 }
 
 template <class T, class B>
-T Dataset<T, B>::tokenize_spm(
+T Dataset<T, B>::tokenize_bpe(
     const std::string& ikey,
-    std::shared_ptr<core::Trie<char>> trie,
-    bool insert_space,
+    std::shared_ptr<const core::Trie<char>> symbols,
+    std::shared_ptr<const core::BPEMerges> merges,
     const std::string& okey) const {
-  static const std::string space = " ";
-  static const std::string new_space = "▁";
-
-  std::string okey_ = (okey.empty()) ? ikey : okey;
-
-  return (sample_transform_if(
-              !okey.empty(),
-              [ikey, okey](const Sample& s) {
-                auto new_sample = s;
-                new_sample[okey] = new_sample[ikey];
-                return new_sample;
-              })
-              .pad_if(insert_space, okey_, 0, 1, 0, 32)
-              .replace(okey_, space, new_space)
-              .tokenize(okey_, trie, TokenizeMode::shortest));
+  return transform_(
+      std::make_shared<op::BPETokenize>(ikey, symbols, merges, okey));
 }
 
 template <class T, class B>
-T Dataset<T, B>::tokenize_spm_if(
+T Dataset<T, B>::tokenize_bpe_if(
     bool cond,
     const std::string& ikey,
-    std::shared_ptr<core::Trie<char>> trie,
-    bool insert_space,
+    std::shared_ptr<const core::Trie<char>> symbols,
+    std::shared_ptr<const core::BPEMerges> merges,
     const std::string& okey) const {
   if (cond) {
-    return tokenize_spm(ikey, trie, insert_space, okey);
+    return transform_(
+        std::make_shared<op::BPETokenize>(ikey, symbols, merges, okey));
   } else {
     return T(self_);
   }

--- a/mlx/data/Dataset.h
+++ b/mlx/data/Dataset.h
@@ -456,16 +456,16 @@ class Dataset {
       bool ignore_unk = false,
       const std::vector<double>& trie_key_scores = {},
       const std::string& okey = "") const;
-  T tokenize_spm(
+  T tokenize_bpe(
       const std::string& ikey,
-      std::shared_ptr<core::Trie<char>> trie,
-      bool insert_space = true,
+      std::shared_ptr<const core::Trie<char>> symbols,
+      std::shared_ptr<const core::BPEMerges> merges,
       const std::string& okey = "") const;
-  T tokenize_spm_if(
+  T tokenize_bpe_if(
       bool cond,
       const std::string& ikey,
-      std::shared_ptr<core::Trie<char>> trie,
-      bool insert_space = true,
+      std::shared_ptr<const core::Trie<char>> symbols,
+      std::shared_ptr<const core::BPEMerges> merges,
       const std::string& okey = "") const;
 
  protected:

--- a/mlx/data/Dataset.h
+++ b/mlx/data/Dataset.h
@@ -456,6 +456,17 @@ class Dataset {
       bool ignore_unk = false,
       const std::vector<double>& trie_key_scores = {},
       const std::string& okey = "") const;
+  T tokenize_spm(
+      const std::string& ikey,
+      std::shared_ptr<core::Trie<char>> trie,
+      bool insert_space = true,
+      const std::string& okey = "") const;
+  T tokenize_spm_if(
+      bool cond,
+      const std::string& ikey,
+      std::shared_ptr<core::Trie<char>> trie,
+      bool insert_space = true,
+      const std::string& okey = "") const;
 
  protected:
   std::shared_ptr<B> self_;

--- a/mlx/data/core/BPETokenizer.cpp
+++ b/mlx/data/core/BPETokenizer.cpp
@@ -1,0 +1,158 @@
+// Copyright © 2024 Apple Inc.
+
+#include <iostream>
+#include <list>
+#include <queue>
+#include <sstream>
+
+#include "mlx/data/core/BPETokenizer.h"
+#include "mlx/data/core/Trie.h"
+
+namespace mlx {
+namespace data {
+namespace core {
+
+void BPEMerges::add(
+    const std::string& left,
+    const std::string& right,
+    int64_t token) {
+  auto [left_s, left_inserted] = strings_.insert(left);
+  auto [right_s, right_inserted] = strings_.insert(right);
+
+  std::string_view left_v(*left_s);
+  std::string_view right_v(*right_s);
+
+  auto left_it = merges_.find(left_v);
+  if (left_it == merges_.end()) {
+    merges_[left_v][right_v] = token;
+  } else {
+    auto right_it = left_it->second.find(right_v);
+    if (right_it == left_it->second.end()) {
+      left_it->second[right_v] = token;
+    } else {
+      right_it->second = std::min(token, right_it->second);
+    }
+  }
+}
+
+std::pair<bool, int64_t> BPEMerges::can_merge(
+    std::string_view left,
+    std::string_view right) const {
+  auto left_it = merges_.find(left);
+  if (left_it == merges_.end()) {
+    return {false, 0};
+  }
+  auto right_it = left_it->second.find(right);
+  if (right_it == left_it->second.end()) {
+    return {false, 0};
+  }
+  return {true, right_it->second};
+}
+
+BPETokenizer::BPETokenizer(
+    std::shared_ptr<const Trie<char>> symbols,
+    std::shared_ptr<const BPEMerges> merges)
+    : symbols_(symbols), merges_(merges) {}
+
+std::vector<int64_t> BPETokenizer::tokenize(const std::string& input) const {
+  struct Symbol {
+    std::string_view value;
+    int64_t token;
+  };
+
+  struct Pair {
+    std::list<Symbol>::iterator left;
+    std::list<Symbol>::iterator right;
+    int64_t token;
+    std::string_view value;
+
+    Pair(
+        std::list<Symbol>::iterator left,
+        std::list<Symbol>::iterator right,
+        int64_t token)
+        : left(left),
+          right(right),
+          token(token),
+          value(left->value.data(), left->value.size() + right->value.size()) {}
+
+    bool operator<(const Pair& right) const {
+      return token >= right.token;
+    };
+  };
+
+  // Transform the input to a sequence of basic symbols that will subsequently
+  // be merged.
+  std::list<Symbol> symbols;
+  for (auto it = input.begin(); it != input.end(); it++) {
+    auto [node, length] = symbols_->search_longest_prefix(it, input.end());
+    if (length == 0) {
+      std::ostringstream msg;
+      msg << "BPETokenizer: Unknown symbol '" << *it << "'";
+      throw std::runtime_error(msg.str());
+    }
+    symbols.push_back(Symbol{std::string_view(&*it, length), node->id});
+    it += length - 1;
+  }
+
+  std::priority_queue<Pair> merge_queue;
+
+  // Initialize the merge queue
+  auto left = symbols.begin();
+  auto right = std::next(left);
+  while (right != symbols.end()) {
+    auto [can_merge, token] = merges_->can_merge(left->value, right->value);
+    if (can_merge) {
+      merge_queue.emplace(left, right, token);
+    }
+    left++;
+    right++;
+  }
+
+  while (!merge_queue.empty()) {
+    Pair pair = std::move(merge_queue.top());
+    merge_queue.pop();
+
+    // If both left and right are valid and the value matches the pair value it
+    // means we can merge freely.
+    if (pair.left->token >= 0 && pair.right->token >= 0 &&
+        pair.value.size() ==
+            pair.left->value.size() + pair.right->value.size() &&
+        pair.value.data() == pair.left->value.data()) {
+      pair.left->token = pair.token;
+      pair.left->value = pair.value;
+      pair.right->token = -1;
+      continue;
+    }
+
+    // This means that the pair is invalid for some reason, so we "eat" left
+    // and right until they both have valid symbols. Subsequently we push the
+    // new pair in the merge queue.
+    while (pair.left->token == -1) {
+      pair.left = symbols.erase(pair.left);
+      pair.left--;
+    }
+    while (pair.right != symbols.end() && pair.right->token == -1) {
+      pair.right = symbols.erase(pair.right);
+    }
+
+    auto [can_merge, token] =
+        merges_->can_merge(pair.left->value, pair.right->value);
+    if (can_merge) {
+      merge_queue.emplace(pair.left, pair.right, token);
+    }
+  }
+
+  // Gather the final result in a vector
+  std::vector<int64_t> tokens;
+  for (auto& symbol : symbols) {
+    if (symbol.token >= 0) {
+      tokens.push_back(symbol.token);
+    }
+  }
+
+  return tokens;
+}
+
+} // namespace core
+} // namespace data
+} // namespace mlx

--- a/mlx/data/core/BPETokenizer.cpp
+++ b/mlx/data/core/BPETokenizer.cpp
@@ -54,7 +54,7 @@ BPETokenizer::BPETokenizer(
     std::shared_ptr<const BPEMerges> merges)
     : symbols_(symbols), merges_(merges) {}
 
-std::vector<int64_t> BPETokenizer::tokenize(const std::string& input) const {
+std::vector<int64_t> BPETokenizer::tokenize(std::string_view input) const {
   struct Symbol {
     std::string_view value;
     int64_t token;

--- a/mlx/data/core/BPETokenizer.h
+++ b/mlx/data/core/BPETokenizer.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <memory>
 #include <unordered_map>
 #include <unordered_set>
 

--- a/mlx/data/core/BPETokenizer.h
+++ b/mlx/data/core/BPETokenizer.h
@@ -1,0 +1,53 @@
+// Copyright © 2024 Apple Inc.
+
+#pragma once
+
+#include <unordered_map>
+#include <unordered_set>
+
+#include "mlx/data/core/Trie.h"
+
+namespace mlx {
+namespace data {
+namespace core {
+
+class BPEMerges {
+ public:
+  void add(const std::string& left, const std::string& right, int64_t token);
+  std::pair<bool, int64_t> can_merge(
+      std::string_view left,
+      std::string_view right) const;
+
+  template <typename iterator_type>
+  std::pair<bool, int64_t>
+  can_merge(iterator_type left, iterator_type middle, iterator_type end) const {
+    // switch to std::string_view(left, middle) when in C++20
+    return can_merge(
+        std::string_view(&(*left), std::distance(left, middle)),
+        std::string_view(&(*middle), std::distance(middle, end)));
+  }
+
+ private:
+  std::unordered_set<std::string> strings_;
+  std::unordered_map<
+      std::string_view,
+      std::unordered_map<std::string_view, int64_t>>
+      merges_;
+};
+
+class BPETokenizer {
+ public:
+  BPETokenizer(
+      std::shared_ptr<const Trie<char>> symbols,
+      std::shared_ptr<const BPEMerges> merges);
+
+  std::vector<int64_t> tokenize(const std::string& input) const;
+
+ private:
+  std::shared_ptr<const Trie<char>> symbols_;
+  std::shared_ptr<const BPEMerges> merges_;
+};
+
+} // namespace core
+} // namespace data
+} // namespace mlx

--- a/mlx/data/core/BPETokenizer.h
+++ b/mlx/data/core/BPETokenizer.h
@@ -41,7 +41,7 @@ class BPETokenizer {
       std::shared_ptr<const Trie<char>> symbols,
       std::shared_ptr<const BPEMerges> merges);
 
-  std::vector<int64_t> tokenize(const std::string& input) const;
+  std::vector<int64_t> tokenize(std::string_view input) const;
 
  private:
   std::shared_ptr<const Trie<char>> symbols_;

--- a/mlx/data/core/Trie.h
+++ b/mlx/data/core/Trie.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <deque>
+#include <iterator>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -32,44 +33,83 @@ class Trie {
     nodes_.resize(1);
     nodes_.back().id = -1; // uid is 0
   };
-  const TrieNode<T>* insert(const std::vector<T>& key) {
-    TrieNode<T>* node;
-    int64_t i;
-    std::tie(node, i) = partial_search_(key);
-    for (; i < key.size(); i++) {
+
+  template <typename iterator_type>
+  std::tuple<const TrieNode<T>*, int64_t> search_longest_prefix(
+      iterator_type it,
+      iterator_type end) const {
+    auto node = root_();
+    int64_t i = 0;
+    auto valid_node = node;
+    int64_t valid_i = i;
+    while (it != end) {
+      auto kv = node->children.find(*it);
+      if (kv == node->children.end()) {
+        break;
+      } else {
+        node = kv->second;
+        i++;
+        it++;
+        if (node->accepts()) {
+          valid_node = node;
+          valid_i = i;
+        }
+      }
+    }
+    return std::make_tuple(valid_node, valid_i);
+  }
+
+  template <typename iterator_type>
+  const TrieNode<T>* insert(iterator_type begin, iterator_type end) {
+    auto it = begin;
+    auto [node, i] = partial_search(it, end);
+    std::advance(it, i); // it += i but also supports sequential iterators
+    while (it != end) {
       nodes_.resize(nodes_.size() + 1);
       TrieNode<T>* new_node = &nodes_.back();
       new_node->uid = nodes_.size() - 1;
       new_node->id = -1;
-      node->children[key[i]] = new_node;
+      node->children[*it] = new_node;
       node = new_node;
+      it++;
     }
     if (!node->accepts()) {
       node->id = keys_.size();
-      keys_.push_back(key);
+      keys_.emplace_back(begin, end);
     }
     return node;
-  };
-  const TrieNode<T>* search(const std::vector<T>& key) {
-    auto res = partial_search_(key);
-    if (std::get<1>(res) != key.size()) {
+  }
+
+  template <typename iterator_type>
+  const TrieNode<T>* search(iterator_type it, iterator_type end) {
+    auto [node, i] = partial_search(it, end);
+    if (i != std::distance(it, end) || !node->accepts()) {
       return nullptr;
-    } else {
-      auto node = std::get<0>(res);
-      return (node->accepts() ? node : nullptr);
     }
-  };
+    return node;
+  }
+
+  const TrieNode<T>* insert(const std::vector<T>& key) {
+    return insert(key.begin(), key.end());
+  }
+
+  const TrieNode<T>* search(const std::vector<T>& key) {
+    return search(key.begin(), key.end());
+  }
+
   const TrieNode<T>* root() const {
     return &nodes_.front();
   }
+
   int64_t num_keys() const {
     return keys_.size();
   }
+
   const std::vector<T>& key(int64_t id) const {
     return keys_.at(id);
   }
 
-  // helper for strings
+  // helpers for strings
   template <
       typename U = T,
       std::enable_if_t<std::is_same<char, U>::value, char> = false>
@@ -94,19 +134,30 @@ class Trie {
   TrieNode<T>* root_() {
     return &nodes_.front();
   }
-  std::tuple<TrieNode<T>*, int64_t> partial_search_(const std::vector<T>& key) {
+
+  const TrieNode<T>* root_() const {
+    return &nodes_.front();
+  }
+
+  template <typename iterator_type>
+  std::tuple<TrieNode<T>*, int64_t> partial_search(
+      iterator_type it,
+      iterator_type end) {
     auto node = root_();
     int64_t i = 0;
-    for (; i < key.size(); i++) {
-      auto kv = node->children.find(key[i]);
+    while (it != end) {
+      auto kv = node->children.find(*it);
       if (kv == node->children.end()) {
         break;
       } else {
         node = kv->second;
+        i++;
+        it++;
       }
     }
     return std::make_tuple(node, i);
   }
+
   std::deque<TrieNode<T>> nodes_;
   std::vector<std::vector<T>> keys_;
 };

--- a/mlx/data/core/Trie.h
+++ b/mlx/data/core/Trie.h
@@ -60,7 +60,9 @@ class Trie {
   }
 
   template <typename iterator_type>
-  const TrieNode<T>* insert(iterator_type begin, iterator_type end) {
+  const TrieNode<T>*
+  insert(iterator_type begin, iterator_type end, int64_t id = -1) {
+    id = (id < 0) ? keys_.size() : id;
     auto it = begin;
     auto [node, i] = partial_search(it, end);
     std::advance(it, i); // it += i but also supports sequential iterators
@@ -74,8 +76,8 @@ class Trie {
       it++;
     }
     if (!node->accepts()) {
-      node->id = keys_.size();
-      keys_.emplace_back(begin, end);
+      node->id = id;
+      keys_.emplace(id, std::vector<T>(begin, end));
     }
     return node;
   }
@@ -89,8 +91,8 @@ class Trie {
     return node;
   }
 
-  const TrieNode<T>* insert(const std::vector<T>& key) {
-    return insert(key.begin(), key.end());
+  const TrieNode<T>* insert(const std::vector<T>& key, int64_t id = -1) {
+    return insert(key.begin(), key.end(), id);
   }
 
   const TrieNode<T>* search(const std::vector<T>& key) {
@@ -113,14 +115,14 @@ class Trie {
   template <
       typename U = T,
       std::enable_if_t<std::is_same<char, U>::value, char> = false>
-  const TrieNode<T>* insert(const std::string& key) {
-    return insert(std::vector<T>(key.begin(), key.end()));
+  const TrieNode<T>* insert(const std::string& key, int64_t id = -1) {
+    return insert(key.begin(), key.end(), id);
   };
   template <
       typename U = T,
       std::enable_if_t<std::is_same<char, U>::value, char> = false>
   const TrieNode<T>* search(const std::string& key) {
-    return search(std::vector<T>(key.begin(), key.end()));
+    return search(key.begin(), key.end());
   };
   template <
       typename U = T,
@@ -159,7 +161,7 @@ class Trie {
   }
 
   std::deque<TrieNode<T>> nodes_;
-  std::vector<std::vector<T>> keys_;
+  std::unordered_map<int64_t, std::vector<T>> keys_;
 };
 
 } // namespace core

--- a/mlx/data/op/Tokenize.cpp
+++ b/mlx/data/op/Tokenize.cpp
@@ -5,6 +5,7 @@
 namespace mlx {
 namespace data {
 namespace op {
+
 Tokenize::Tokenize(
     const std::string& ikey,
     std::shared_ptr<core::Trie<char>> trie,
@@ -15,6 +16,7 @@ Tokenize::Tokenize(
     : KeyTransformOp(ikey, okey),
       tokenizer_(trie, ignore_unk, trie_key_scores),
       mode_(mode) {}
+
 std::shared_ptr<Array> Tokenize::apply_key(
     const std::shared_ptr<const Array>& src) const {
   std::string str(
@@ -34,6 +36,21 @@ std::shared_ptr<Array> Tokenize::apply_key(
 
   return std::make_shared<Array>(tokens);
 }
+
+BPETokenize::BPETokenize(
+    const std::string& ikey,
+    std::shared_ptr<const core::Trie<char>> symbols,
+    std::shared_ptr<const core::BPEMerges> merges,
+    const std::string& okey)
+    : KeyTransformOp(ikey, okey), tokenizer_(symbols, merges) {}
+
+std::shared_ptr<Array> BPETokenize::apply_key(
+    const std::shared_ptr<const Array>& src) const {
+  auto tokens = tokenizer_.tokenize(std::string_view(
+      reinterpret_cast<char*>(src->data()), src->size() * src->itemsize()));
+  return std::make_shared<Array>(tokens);
+}
+
 } // namespace op
 } // namespace data
 } // namespace mlx

--- a/mlx/data/op/Tokenize.h
+++ b/mlx/data/op/Tokenize.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "mlx/data/core/BPETokenizer.h"
 #include "mlx/data/core/Tokenizer.h"
 #include "mlx/data/core/Trie.h"
 #include "mlx/data/op/KeyTransform.h"
@@ -28,6 +29,21 @@ class Tokenize : public KeyTransformOp {
  private:
   core::Tokenizer tokenizer_;
   TokenizeMode mode_;
+};
+
+class BPETokenize : public KeyTransformOp {
+ public:
+  BPETokenize(
+      const std::string& ikey,
+      std::shared_ptr<const core::Trie<char>> symbols,
+      std::shared_ptr<const core::BPEMerges> merges,
+      const std::string& okey = "");
+
+  virtual std::shared_ptr<Array> apply_key(
+      const std::shared_ptr<const Array>& src) const override;
+
+ private:
+  core::BPETokenizer tokenizer_;
 };
 
 } // namespace op

--- a/python/mlx/data/tokenizer_helpers.py
+++ b/python/mlx/data/tokenizer_helpers.py
@@ -246,7 +246,7 @@ def read_bpe_from_hf(json_file, add_special_tokens=True):
     merged_tokens = set()
     merges = BPEMerges()
     for merge in tokenizer["model"]["merges"]:
-        a, b = merge.split(" ")
+        a, b = merge.split(" ") if isinstance(merge, str) else merge
         ab = a + b
         merged_tokens.add(ab)
         merges.add(a, b, vocab[ab])

--- a/python/mlx/data/tokenizer_helpers.py
+++ b/python/mlx/data/tokenizer_helpers.py
@@ -122,6 +122,25 @@ def read_trie_from_spm(spm_file):
 
 
 def read_bpe_from_spm(spm_file):
+    """Read a sentencepiece file and decompose it to a symbol trie and BPE
+    merges for use with :class:`mlx.data.core.BPETokenizer`.
+
+    Because it isn't straightforward to extract the merges from the SPM file,
+    we create a trie of basic symbols by considering all single unicode
+    character tokens as basic symbols as well as any special tokens provided.
+
+    To extract the merges we run the BPE algorithm on the tokens in order of
+    probability as suggested in https://github.com/openai/tiktoken/issues/60
+    for exporting an SPM model to huggingface tokenizers.
+
+    Args:
+        spm_file (str): Either a sentencepiece model file or a vocab file
+            extracted from a sentencepiece model.
+
+    Returns:
+        tuple[:class:`mlx.data.core.CharTrie`, :class:`mlx.data.core.BPEMerges`]: The
+        trie and the corresponding BPE merges from the SPM mdoel.
+    """
     symbols = []
     merged = []
     tokenmap = {}

--- a/python/src/wrap_core.cpp
+++ b/python/src/wrap_core.cpp
@@ -134,21 +134,26 @@ void init_mlx_data_core(py::module& m) {
       .def(
           "insert",
           [](std::shared_ptr<Trie<char>> trie,
-             std::variant<std::string, std::vector<char>> token) {
+             std::variant<std::string, std::vector<char>> token,
+             int64_t id) {
             if (std::holds_alternative<std::string>(token)) {
-              return trie->insert(std::get<std::string>(token));
+              return trie->insert(std::get<std::string>(token), id);
             } else {
-              return trie->insert(std::get<std::vector<char>>(token));
+              return trie->insert(std::get<std::vector<char>>(token), id);
             }
           },
           py::return_value_policy::reference_internal,
           py::arg("token"),
+          py::arg("id") = -1,
           R"pbcopy(
             Insert a token in the trie making a new token if it doesn't already exist.
 
             Args:
                 token (str or list[char]): The new token to be inserted given
                   either as a string or a list of characters.
+                id (int, optional): The id to assign to the new token to be
+                  inserted. If negative then use ``num_keys()`` as default.
+                  Default: ``-1``.
           )pbcopy")
       .def(
           "search",

--- a/python/src/wrap_core.cpp
+++ b/python/src/wrap_core.cpp
@@ -8,6 +8,7 @@
 #include "mlx/data/core/AWSFileFetcher.h"
 #endif
 
+#include "mlx/data/core/BPETokenizer.h"
 #include "mlx/data/core/FileFetcher.h"
 #include "mlx/data/core/Graph.h"
 #include "mlx/data/core/Levenshtein.h"
@@ -274,6 +275,86 @@ void init_mlx_data_core(py::module& m) {
             Args:
                 input (str): The input string to be tokenized.
            )pbcopy");
+
+  py::class_<BPEMerges, std::shared_ptr<BPEMerges>>(
+      m,
+      "BPEMerges",
+      R"pbcopy(
+        A datastructure that holds all possible merges and allows querying
+        whether two strings can be merged in O(1) time.
+      )pbcopy")
+      .def(py::init<>())
+      .def(
+          "add",
+          &BPEMerges::add,
+          py::arg("left"),
+          py::arg("right"),
+          py::arg("token"),
+          R"pbcopy(
+            Add two strings as a possible merge that results in ``token``.
+
+            Args:
+              left (str): The left side to be merged.
+              right (str): The right side to be merged.
+              token (int): The resulting token.
+          )pbcopy")
+      .def(
+          "can_merge",
+          [](std::shared_ptr<BPEMerges>& merges,
+             const std::string& left,
+             const std::string& right) -> std::optional<int64_t> {
+            auto [can_merge, token] = merges->can_merge(
+                std::string_view(left.data(), left.size()),
+                std::string_view(right.data(), right.size()));
+
+            if (!can_merge) {
+              return {};
+            }
+
+            return token;
+          },
+          py::arg("left"),
+          py::arg("right"),
+          R"pbcopy(
+            Check if ``left`` and ``right`` can be merged to one token.
+
+            Args:
+              left (str): The left side of the possible token.
+              right (str): The right side of the possible token.
+
+            Returns:
+              The token id is returned or None if ``left`` and ``right``
+              couldn't be merged.
+          )pbcopy");
+
+  py::class_<BPETokenizer, std::shared_ptr<BPETokenizer>>(
+      m,
+      "BPETokenizer",
+      R"pbcopy(
+        A tokenizer that uses the BPE algorithm to tokenize strings.
+
+        Args:
+          symbol_trie (mlx.data.core.CharTrie): The trie containing the basic
+            symbols that all merges start from.
+          merges (mlx.data.core.BPEMerges): The datastructure holding the bpe
+            merges.
+      )pbcopy")
+      .def(
+          py::init<
+              std::shared_ptr<const Trie<char>>,
+              std::shared_ptr<const BPEMerges>>(),
+          py::arg("symbols"),
+          py::arg("merges"))
+      .def(
+          "tokenize",
+          &BPETokenizer::tokenize,
+          py::arg("input"),
+          R"pbcopy(
+            Tokenize the input according to the symbols and merges.
+
+            Args:
+              input (str): The input string to be tokenized.
+          )pbcopy");
 
   py::class_<FileFetcherHandle, std::shared_ptr<FileFetcherHandle>>(
       m, "FileFetcherHandle");

--- a/python/src/wrap_dataset.h
+++ b/python/src/wrap_dataset.h
@@ -1374,46 +1374,38 @@ void mlx_data_export_dataset(py::class_<T, P>& base) {
       "Conditional :meth:`Buffer.tokenize`.");
 
   base.def(
-      "tokenize_spm",
-      &T::tokenize_spm,
+      "tokenize_bpe",
+      &T::tokenize_bpe,
       py::call_guard<py::gil_scoped_release>(),
       py::arg("key"),
-      py::arg("trie"),
-      py::arg("insert_space") = true,
+      py::arg("symbols"),
+      py::arg("merges"),
       py::arg("output_key") = "",
       R"pbcopy(
-        Preprocess the contents of the array at ``key`` and tokenize them
-        according to the SentencePiece tokenizer.
+        Tokenize the the contents of the array at ``key`` using the BPE merging
+        algorithm.
 
-        This call is simply a convenience over calling pad, replace and
-        tokenize as follows:
-
-        .. code-block:: python
-
-          dset = (
-            dset
-            .pad("text", 0, 1, 0, ord(" "), output_key="tokens")
-            .replace("tokens", " ", "\u2581")
-            .tokenize("tokens", trie)
-          )
+        For instance this can be used to match the tokenization of the
+        Sentencepiece tokenizers.
 
         Args:
           key (str): The sample key that contains the array we are operating on.
-          trie (mlx.data.core.CharTrie): The trie to use for the tokenization.
-          insert_space (bool): Whether to prepend a space before the text.
-            (default: ``True``).
+          symbols (mlx.data.core.CharTrie): A trie containing the basic symbols
+            to use for the tokenization.
+          merges (mlx.data.core.BPEMerges): A datastructure containing the
+            merges of the basic symbols in order of priority.
           output_key (str): If it is not empty then write the result to this
             key instead of overwriting ``key``. (default: '')
       )pbcopy");
   base.def(
-      "tokenize_spm_if",
-      &T::tokenize_spm_if,
+      "tokenize_bpe_if",
+      &T::tokenize_bpe_if,
       py::call_guard<py::gil_scoped_release>(),
       py::arg("cond"),
       py::arg("key"),
-      py::arg("trie"),
-      py::arg("insert_space") = true,
+      py::arg("symbols"),
+      py::arg("merges"),
       py::arg("output_key") = "",
-      "Conditional :meth:`Buffer.tokenize_spm`.");
+      "Conditional :meth:`Buffer.tokenize_bpe`.");
 }
 } // namespace

--- a/python/src/wrap_dataset.h
+++ b/python/src/wrap_dataset.h
@@ -1372,5 +1372,48 @@ void mlx_data_export_dataset(py::class_<T, P>& base) {
       py::arg("trie_key_scores") = std::vector<double>({}),
       py::arg("output_key") = "",
       "Conditional :meth:`Buffer.tokenize`.");
+
+  base.def(
+      "tokenize_spm",
+      &T::tokenize_spm,
+      py::call_guard<py::gil_scoped_release>(),
+      py::arg("key"),
+      py::arg("trie"),
+      py::arg("insert_space") = true,
+      py::arg("output_key") = "",
+      R"pbcopy(
+        Preprocess the contents of the array at ``key`` and tokenize them
+        according to the SentencePiece tokenizer.
+
+        This call is simply a convenience over calling pad, replace and
+        tokenize as follows:
+
+        .. code-block:: python
+
+          dset = (
+            dset
+            .pad("text", 0, 1, 0, ord(" "), output_key="tokens")
+            .replace("tokens", " ", "\u2581")
+            .tokenize("tokens", trie)
+          )
+
+        Args:
+          key (str): The sample key that contains the array we are operating on.
+          trie (mlx.data.core.CharTrie): The trie to use for the tokenization.
+          insert_space (bool): Whether to prepend a space before the text.
+            (default: ``True``).
+          output_key (str): If it is not empty then write the result to this
+            key instead of overwriting ``key``. (default: '')
+      )pbcopy");
+  base.def(
+      "tokenize_spm_if",
+      &T::tokenize_spm_if,
+      py::call_guard<py::gil_scoped_release>(),
+      py::arg("cond"),
+      py::arg("key"),
+      py::arg("trie"),
+      py::arg("insert_space") = true,
+      py::arg("output_key") = "",
+      "Conditional :meth:`Buffer.tokenize_spm`.");
 }
 } // namespace

--- a/python/tests/test_bpe.py
+++ b/python/tests/test_bpe.py
@@ -1,0 +1,31 @@
+# Copyright © 2024 Apple Inc.
+
+import string
+import unittest
+
+from mlx.data.core import BPEMerges, BPETokenizer, CharTrie
+
+
+class TestBpe(unittest.TestCase):
+    def test_bpe(self):
+        symbols = CharTrie()
+        symbols.insert(" ")
+        for s in string.ascii_letters:
+            symbols.insert(s)
+        n = symbols.num_keys()
+        merges = BPEMerges()
+
+        tokenizer = BPETokenizer(symbols, merges)
+
+        self.assertEqual(tokenizer.tokenize("abcd"), [1, 2, 3, 4])
+
+        merges.add("a", "b", n + 1)
+        self.assertEqual(tokenizer.tokenize("abcd"), [n + 1, 3, 4])
+
+        merges.add("c", "d", n + 2)
+        merges.add("b", "cd", n + 3)
+        self.assertEqual(tokenizer.tokenize("abcd"), [n + 1, n + 2])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR is on top of #61 and I will rebase to simplify the diff once that is merged. Please ignore "replace" related code here.

The changes in this PR are to support an implementation of BPE tokenizers. It adds a bunch of functionality to the `Trie` and it also adds a `BPEMerges` data structure which is a thin wrapper on top of a map of maps. No backwards incompatible changes anywhere except `read_trie_from_spm` which now doesn't change the space character and results in closer tokenizations to SPM even when not using BPE.

#### Trie
- Most things are moved to work with iterators internally which removes a bunch of `std::vector<char>` creations and copies.
- Add `search_longest_prefix` which the `Trie` is perfect for
- Add the ability to set the `id` when inserting
- Changed the vector that holds the keys to an `unordered_map` to support the above

#### BPE
- BPETokenizer::tokenize would be the most interesting function. It is not the prettiest implementation but it is pretty fast and beats SPM on my laptop. Possible room for improvement lines 135-160 where we search for neighbors with linear search.
- `read_bpe_from_spm` ironically implements a small bpe in python to extract the merges from the file.

#### TL;DR

The following is implementing SPM tokenization so far with exactly identical results as spm or HF.

```python
symbols, merges = read_bpe_from_spm("tokenizer.model")
ds = (
    ds
    .pad("text", 0, 1, 0, ord(" "))
    .replace("text", " ", "\u2581")
    .tokenize_bpe("text", symbols, merges)
)
```