### PR TITLE
Add `Path` import to cifar file

### DIFF
--- a/python/mlx/data/datasets/cifar.py
+++ b/python/mlx/data/datasets/cifar.py
@@ -9,7 +9,13 @@ from tempfile import NamedTemporaryFile
 import numpy as np
 
 from ... import data as dx
-from .common import CACHE_DIR, ensure_exists, file_digest, urlretrieve_with_progress
+from .common import (
+    CACHE_DIR,
+    Path,
+    ensure_exists,
+    file_digest,
+    urlretrieve_with_progress,
+)
 
 URLS = {
     "CIFAR10": (

--- a/python/mlx/data/datasets/cifar.py
+++ b/python/mlx/data/datasets/cifar.py
@@ -4,18 +4,13 @@ import hashlib
 import pickle
 import shutil
 import tarfile
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import numpy as np
 
 from ... import data as dx
-from .common import (
-    CACHE_DIR,
-    Path,
-    ensure_exists,
-    file_digest,
-    urlretrieve_with_progress,
-)
+from .common import CACHE_DIR, ensure_exists, file_digest, urlretrieve_with_progress
 
 URLS = {
     "CIFAR10": (


### PR DESCRIPTION
Simply added `import common.Path` at cifar.py file.

Got an error while following [CIFAR10 example](https://github.com/ml-explore/mlx-examples/tree/main/cifar) and just adding import fixed it.

```
$ (.mlx) ~/MLX/ python CIFAR

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/junnos/MLX/CIFAR/__main__.py", line 67, in <module>
    main(args)
  File "/Users/junnos/MLX/CIFAR/__main__.py", line 35, in main
    datas: tuple[Stream, Stream] = get_cifar10(
                                   ^^^^^^^^^^^^
  File "/Users/junnos/MLX/CIFAR/dataset.py", line 9, in get_cifar10
    trainset: Buffer = load_cifar10(root=root, train=True)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/junnos/MLX/.mlx/lib/python3.12/site-packages/mlx/data/datasets/cifar.py", line 115, in load_cifar10
    root = Path(root)
           ^^^^
NameError: name 'Path' is not defined
```