### PR TITLE
Make tokenizer_helpers being imported

### DIFF
--- a/python/mlx/data/__init__.py
+++ b/python/mlx/data/__init__.py
@@ -11,3 +11,5 @@ from ._c import __version__
 # alternatively, one can set OPENBLAS_NUM_THREADS=1.
 import numpy  # isort: skip
 del numpy
+
+from . import tokenizer_helpers


### PR DESCRIPTION
Support the case of 

```
import mlx.data as dx
dx.tokenizer_helpers.xxx
```