### PR TITLE
Add ordered_prefetch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,7 @@ set(mlxdata-src
     ${CMAKE_CURRENT_LIST_DIR}/mlx/data/stream/CSVReader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mlx/data/stream/FromBuffer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mlx/data/stream/LineReader.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/mlx/data/stream/OrderedPrefetch.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mlx/data/stream/Partition.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mlx/data/stream/Prefetch.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mlx/data/stream/Repeat.cpp

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -9,13 +9,17 @@ class Benchmark:
         self.name = name
         self.runtimes = defaultdict(list)
         self.n_samples = defaultdict(int)
+        self.run_count = 0
 
     def log_run(self, run_name, fn, *args, **kwargs):
+        print(f"Starting run {self.run_count}.", flush=True)
         start = time.time()
         n_samples = fn(*args, **kwargs)
         end = time.time()
         self.runtimes[run_name].append(end - start)
         self.n_samples[run_name] = n_samples
+        print("-------------")
+        self.run_count += 1
 
     def report(self):
         print(f"Benchmark {self.name}")

--- a/docs/src/buffers_streams_samples.rst
+++ b/docs/src/buffers_streams_samples.rst
@@ -101,7 +101,7 @@ and :func:`stream_line_reader` or from a :class:`Buffer` by calling its
 :meth:`Buffer.to_stream` method.
 
 Notably streams enable prefetching (:meth:`Stream.prefetch`) for efficient
-iteration. Continuing the example from above:
+iteration. This prefetching is not deterministic. Continuing the example from above:
 
 .. code-block:: python
 
@@ -115,6 +115,25 @@ iteration. Continuing the example from above:
         .to_stream()  # <-- making a stream from the shuffled buffer
         .batch(32)
         .prefetch(8, 4)  # <-- prefetch 8 batches using 4 threads
+    )
+
+    # Now we can iterate over dset
+    sample = next(dset)
+
+If deterministic prefetching is required, :meth:`Buffer.ordered_prefetch` can replace
+:meth:`Buffer.to_stream`.  
+
+.. code-block:: python
+
+    # We can define the rest of the processing pipeline using streams.
+    # 1. First shuffle the buffer
+    # 2. Make a stream
+    # 3. Batch and then prefetch
+    dset = (
+        dset
+        .shuffle()
+        .batch(32)
+        .ordered_prefetch(8, 4)  # <-- prefetch 8 batches in a stream using 4 threads
     )
 
     # Now we can iterate over dset

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -25,8 +25,8 @@ extensions = [
 autosummary_generate = True
 
 intersphinx_mapping = {
-    "https://docs.python.org/3": None,
-    "https://numpy.org/doc/stable/": None,
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
 }
 
 templates_path = ["_templates"]

--- a/docs/src/hf_datasets_streams.rst
+++ b/docs/src/hf_datasets_streams.rst
@@ -1,5 +1,5 @@
 HuggingFace Datasets and MLX Streams
-============================
+====================================
 
 .. currentmodule:: mlx.data
 

--- a/docs/src/python/buffer.rst
+++ b/docs/src/python/buffer.rst
@@ -47,6 +47,7 @@ transformations that cannot be implemented or do not make sense for a
 .. autosummary::
    :toctree: _autosummary
 
+    Buffer.ordered_prefetch
     Buffer.partition
     Buffer.perm
     Buffer.shuffle

--- a/mlx/data/Buffer.cpp
+++ b/mlx/data/Buffer.cpp
@@ -10,6 +10,7 @@
 #include "mlx/data/buffer/Perm.h"
 #include "mlx/data/buffer/Shuffle.h"
 #include "mlx/data/stream/FromBuffer.h"
+#include "mlx/data/stream/OrderedPrefetch.h"
 
 namespace mlx {
 namespace data {
@@ -57,6 +58,10 @@ Buffer Buffer::dynamic_batch(
     const std::unordered_map<std::string, int>& batch_dims) const {
   return Buffer(std::make_shared<buffer::DynamicBatch>(
       self_, size_buffer.self_, key, max_data_size, pad_values, batch_dims));
+}
+
+Stream Buffer::ordered_prefetch(int prefetch_size, int num_thread) const {
+  return Stream(std::make_shared<stream::OrderedPrefetch>(self_, prefetch_size, num_thread));
 }
 
 Buffer Buffer::partition(int64_t num_partitions, int64_t partition) const {

--- a/mlx/data/Buffer.h
+++ b/mlx/data/Buffer.h
@@ -40,6 +40,8 @@ class Buffer : public Dataset<Buffer, buffer::Buffer> {
       const std::unordered_map<std::string, double>& pad_values = {},
       const std::unordered_map<std::string, int>& batch_dims = {}) const;
 
+  Stream ordered_prefetch(int prefetch_size, int num_thread) const; 
+
   Buffer partition(int64_t num_partitions, int64_t partition) const;
   Buffer partition_if(bool cond, int64_t num_partitions, int64_t partition)
       const;

--- a/mlx/data/stream/OrderedPrefetch.cpp
+++ b/mlx/data/stream/OrderedPrefetch.cpp
@@ -1,0 +1,69 @@
+// Copyright © 2023 Apple Inc.
+
+#include "mlx/data/stream/OrderedPrefetch.h"
+
+namespace mlx {
+namespace data {
+namespace stream {
+
+OrderedPrefetch::OrderedPrefetch(
+    const std::shared_ptr<buffer::Buffer>& buffer,
+    int prefetch_size,
+    int num_thread)
+    : buffer_(buffer),
+      pool_(std::make_shared<core::ThreadPool>(num_thread)),
+      prefetchSize_(prefetch_size),
+      currentIdx_(0) {
+  if (prefetchSize_ <= 0) {
+    throw std::runtime_error(
+        "Prefetch: prefetch size must be strictly positive");
+  }
+}
+
+OrderedPrefetch::~OrderedPrefetch() {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  prefetchCache_.clear();
+}
+
+Sample OrderedPrefetch::next() const {
+  std::unique_lock<std::mutex> lock(mutex_);
+
+  // First time we are called so enqueue all the fetching
+  if (prefetchCache_.size() < prefetchSize_) {
+    for (int i = 0; i < std::min(prefetchSize_, buffer_->size()); i++) {
+      prefetchCache_.emplace_back(
+          pool_->enqueue([b = buffer_, i] { return b->get(i); }));
+    }
+  }
+
+  int64_t idx = -1;
+  if (currentIdx_ < buffer_->size()) {
+    idx = currentIdx_++;
+  }
+
+  if (idx < 0) {
+    return Sample();
+  } else {
+    int f_idx = idx % prefetchSize_;
+    std::future<Sample> fsample(std::move(prefetchCache_[f_idx]));
+    int next_idx = idx + prefetchSize_;
+    if (next_idx < buffer_->size()) {
+      prefetchCache_[f_idx] =
+          pool_->enqueue([b = buffer_, next_idx] { return b->get(next_idx); });
+    }
+    lock.unlock();
+    return fsample.get();
+  }
+}
+
+void OrderedPrefetch::reset() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  currentIdx_ = 0;
+
+  prefetchCache_.clear();
+}
+
+} // namespace stream
+} // namespace data
+} // namespace mlx

--- a/mlx/data/stream/OrderedPrefetch.h
+++ b/mlx/data/stream/OrderedPrefetch.h
@@ -1,0 +1,38 @@
+// Copyright © 2023 Apple Inc.
+
+#pragma once
+
+#include <atomic>
+#include <mutex>
+
+#include "mlx/data/buffer/Buffer.h"
+#include "mlx/data/core/ThreadPool.h"
+#include "mlx/data/stream/Stream.h"
+
+namespace mlx {
+namespace data {
+namespace stream {
+
+class OrderedPrefetch : public Stream {
+ public:
+  OrderedPrefetch(
+      const std::shared_ptr<buffer::Buffer>& stream,
+      int prefetch_size,
+      int num_thread);
+  ~OrderedPrefetch();
+
+  virtual Sample next() const override;
+  virtual void reset() override;
+
+ private:
+  std::shared_ptr<buffer::Buffer> buffer_;
+  std::shared_ptr<core::ThreadPool> pool_;
+  int64_t prefetchSize_;
+  mutable int64_t currentIdx_;
+  mutable std::vector<std::future<Sample>> prefetchCache_;
+  mutable std::mutex mutex_;
+};
+
+} // namespace stream
+} // namespace data
+} // namespace mlx

--- a/python/src/wrap_buffer.cpp
+++ b/python/src/wrap_buffer.cpp
@@ -144,6 +144,43 @@ void init_mlx_data_buffer(py::module& m) {
                   dim (dict): The dimension to concatenate over.
               )pbdoc")
           .def(
+              "ordered_prefetch",
+              &Buffer::ordered_prefetch,
+              py::call_guard<py::gil_scoped_release>(),
+              py::arg("prefetch_size"),
+              py::arg("num_thread"),
+              R"pbcopy(
+                Fetch samples in background threads, while preserving original ordering.
+
+                This operation is the workhorse of data loading. It uses
+                ``num_threads`` background threads and fetches
+                ``prefetch_size`` samples so that they are ready to be used
+                when needed.
+
+                Prefetch can be used both to parallelize operations but also to
+                overlap computation with data loading in a background thread.
+
+                If you don't need deterministic ordering, look for :meth:`Stream.prefetch`
+                instead, as it may be more efficient.
+
+                .. code-block:: python
+
+                  # The final prefetch is parallelizing the whole pipeline and
+                  # ensures that images are going to be available for training.
+                  dset = (
+                    dset
+                    .load_image("image")
+                    .image_resize_smallest_side("image", 256)
+                    .image_center_crop("image", 256, 256)
+                    .batch(32)
+                    .ordered_prefetch(8, 8)
+                  )
+
+                Args:
+                  num_partitions (int): How many different partitions to split the buffer into.
+                  partition (int): Which partition to use (0-based).
+              )pbcopy")
+          .def(
               "partition",
               &Buffer::partition,
               py::call_guard<py::gil_scoped_release>(),

--- a/python/src/wrap_stream.cpp
+++ b/python/src/wrap_stream.cpp
@@ -341,6 +341,10 @@ void init_mlx_data_stream(py::module& m) {
                 Prefetch can be used both to parallelize operations but also to
                 overlap computation with data loading in a background thread.
 
+                This prefetching order is not deterministic and samples' ordering depends
+                on scheduling of the threads. If you need deterministic ordering, look for
+                :meth:`Buffer.ordered_prefetch` instead.
+
                 .. code-block:: python
 
                   # The final prefetch is parallelizing the whole pipeline and

--- a/python/tests/test_buffer.py
+++ b/python/tests/test_buffer.py
@@ -2,6 +2,7 @@
 
 from unittest import TestCase
 
+import pytest
 import mlx.data as dx
 
 
@@ -18,3 +19,24 @@ class TestBuffer(TestCase):
             _ = b[n]
         with self.assertRaises(IndexError):
             _ = b[-(n + 1)]
+
+    def test_ordered_prefetch(self):
+        """Test that elements are fetched in order."""
+        num_threads = 8
+        prefetch_size = 16
+        n = prefetch_size * 10
+        buffer = dx.buffer_from_vector(list(dict(i=i) for i in range(n)))
+        stream = buffer.ordered_prefetch(prefetch_size, num_threads)
+        for i, e in enumerate(stream):
+            self.assertEqual(i, e["i"])
+
+    def test_ordered_prefetch_edge_case(self):
+        """Test when the buffer is smaller than dataset size."""
+        num_threads = 4
+        prefetch_size = 12
+        n = int(prefetch_size * 0.5)
+        buffer = dx.buffer_from_vector(list(dict(i=i) for i in range(n)))
+        stream = buffer.ordered_prefetch(prefetch_size, num_threads)
+        for i, e in enumerate(stream):
+            self.assertEqual(i, e["i"])
+


### PR DESCRIPTION
Here is a possible implementation of the `Buffer.ordered_prefetch` method.

The `OrderedPrefetch` is a `Stream` produced by prefetching in parallel (using a `ThreadPool`) contiguous elements from a `Buffer`. The implementation is an hybrid between `Buffer.to_stream` and `Stream.prefetch`.

`Prefetch` fetches the elements of the queue `prefetchCache_` in order, but the order in which these threads call `Stream.next` is not guaranteed. `OrderedPrefetch` also fetches the elements of a vector `prefetchCache_` in order, but each package task enqueued in the `pool_` is assigned a single `idx` captured by the lambda, that points to an index in the underlying `buffer_`. A `std::lock_guard` is used to ensure atomicity of calls to `OrderedPrefetch .next`. 

Interestingly, the main limitation of this approach is its lack of expressiveness: it must replaces a `Buffer.to_stream` call, but it is not necessarily slower than the original `Prefetch`. However I documented it as a slower counterpart.   

**TODO**:

- [x] Perform a benchmark

Feedbacks are welcome.
