### PR TITLE
Update CI and minor fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,15 @@ jobs:
               $PYBIN/python -m build --wheel
             auditwheel show dist/*
             auditwheel repair dist/*
+      - when:
+          condition:
+            equal: [ << parameters.build_env >>, "PYPI_RELEASE=1" ]
+          steps:
+            - run:
+                name: Upload package
+                command: |
+                  PYBIN=/opt/python/cp<< parameters.python_version >>-cp<< parameters.python_version >>/bin
+                  $PYBIN/python -m twine upload wheelhouse/*
       - store_artifacts:
           path: wheelhouse/
 
@@ -157,6 +166,15 @@ jobs:
               python -m build --wheel
             delocate-listdeps dist/*
             delocate-wheel dist/*
+      - when:
+          condition:
+            equal: [ << parameters.build_env >>, "PYPI_RELEASE=1" ]
+          steps:
+            - run:
+                name: Upload package
+                command: |
+                  source env/bin/activate
+                  twine upload dist/*
       - store_artifacts:
           path: dist/
 
@@ -172,8 +190,6 @@ workflows:
     jobs:
       - linux_build_on_commit
       - mac_build_on_commit
-      - linux_build_wheels
-      - mac_build_wheels
   prb:
     when:
       matches:
@@ -186,6 +202,7 @@ workflows:
           requires: [ hold ]
       - mac_build_on_commit:
           requires: [ hold ]
+
   build_dev_release:
     when:
       and:
@@ -195,14 +212,14 @@ workflows:
       - linux_build_wheels:
           matrix:
             parameters:
-              python_version: ["38", "39", "310", "311", "312"]
+              python_version: ["39", "310", "311", "312", "313"]
               extra_env: ["DEV_RELEASE=1"]
-      #- mac_build_wheels:
-      #    matrix:
-      #      parameters:
-      #        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-      #        macos_version: ["13", "14"]
-      #        extra_env: ["DEV_RELEASE=1"]
+      - mac_build_wheels:
+          matrix:
+            parameters:
+              python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+              xcode_version: ["15.0.0", "15.2.0"]
+              extra_env: ["DEV_RELEASE=1"]
 
   build_pypi_release:
     when:
@@ -213,11 +230,11 @@ workflows:
       - linux_build_wheels:
           matrix:
             parameters:
-              python_version: ["38", "39", "310", "311", "312"]
+              python_version: ["39", "310", "311", "312", "313"]
               extra_env: ["PYPI_RELEASE=1"]
-      #- mac_build_wheels:
-      #    matrix:
-      #      parameters:
-      #        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-      #        macos_version: ["13", "14"]
-      #        extra_env: ["PYPI_RELEASE=1"]
+      - mac_build_wheels:
+          matrix:
+            parameters:
+              python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+              xcode_version: ["15.0.0", "15.2.0"]
+              extra_env: ["PYPI_RELEASE=1"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,41 +61,40 @@ jobs:
       - store_test_results:
           path: test-results
 
-#  mac_build_on_commit:
-#    machine: true
-#    resource_class: ml-explore/m-builder
-#    parameters:
-#      python_version:
-#        type: string
-#        default: "3.9"
-#      macos_version:
-#        type: string
-#        default: "14"
-#      extra_env:
-#        type: string
-#        default: ""
-#    steps:
-#      - checkout
-#      - run:
-#          name: Install dependencies
-#          command: |
-#            eval "$(conda shell.bash hook)"
-#            rm -r $CONDA_PREFIX/envs/runner-env
-#            conda create -y -n runner-env python=3.9
-#            conda activate runner-env
-#            pip install --upgrade cmake
-#            pip install --upgrade pybind11[global]
-#            pip install numpy
-#            pip install twine
-#      - run:
-#          name: Build package
-#          command: |
-#            eval "$(conda shell.bash hook)"
-#            conda activate runner-env
-#            DEVELOPER_DIR=$(developer_dir_macos_14) \
-#              CMAKE_BUILD_PARALLEL_LEVEL="" \
-#              CMAKE_ARGS="-DMLX_ENABLE_AWS=ON" \
-#              python setup.py bdist_wheel
+  mac_build_on_commit:
+    parameters:
+      xcode_version:
+        type: string
+        default: "15.0.0"
+    macos:
+      xcode: << parameters.xcode_version >>
+    resource_class: macos.m1.medium.gen1
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            brew install python@3.9
+            brew install libsndfile libsamplerate ffmpeg jpeg-turbo zlib bzip2 xz aws-sdk-cpp
+            python3.9 -m venv env
+            source env/bin/activate
+            pip install --upgrade cmake
+            pip install --upgrade pybind11[global]
+            pip install numpy
+            pip install unittest-xml-reporting
+      - run:
+          name: Build package
+          command: |
+            source env/bin/activate
+            CMAKE_ARGS="-DMLX_ENABLE_AWS=ON" \
+              python setup.py develop
+      - run:
+          name: Run Python tests
+          command: |
+            source env/bin/activate
+            python -m xmlrunner discover -v python/tests -o test-results/
+      - store_test_results:
+          path: test-results
 
   linux_build_wheels:
     parameters:
@@ -170,7 +169,7 @@ workflows:
         - not: << pipeline.parameters.pypi_release >>
     jobs:
       - linux_build_on_commit
-      #- mac_build_on_commit
+      - mac_build_on_commit
   prb:
     when:
       matches:
@@ -181,8 +180,8 @@ workflows:
           type: approval
       - linux_build_on_commit:
           requires: [ hold ]
-      #- mac_build_on_commit:
-      #    requires: [ hold ]
+      - mac_build_on_commit:
+          requires: [ hold ]
   build_dev_release:
     when:
       and:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  apple: ml-explore/pr-approval@0.1.0
+
 parameters:
   dev_release:
     type: boolean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,9 @@ workflows:
   build_on_commit:
     when:
       and:
-        - equal: [ main, << pipeline.git.branch >> ]
+        - matches:
+            pattern: "^(?!pull/)[-\\w]+$"
+            value: << pipeline.git.branch >>
         - not: << pipeline.parameters.dev_release >>
         - not: << pipeline.parameters.pypi_release >>
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
             pip install --upgrade cmake
             pip install --upgrade pybind11[global]
             pip install numpy
-            pip install twine
+            pip install unittest-xml-reporting
             sudo apt-get update
             sudo apt install libsndfile1-dev libsamplerate0-dev ffmpeg libjpeg-turbo8-dev \
               zlib1g-dev libbz2-dev liblzma-dev
@@ -53,7 +53,13 @@ jobs:
           name: Build package
           command: |
             CMAKE_ARGS="-DMLX_ENABLE_AWS=ON" \
-              python setup.py bdist_wheel
+              python setup.py develop
+      - run:
+          name: Run Python tests
+          command: |
+            python -m xmlrunner discover -v python/tests -o test-results/
+      - store_test_results:
+          path: test-results
 
 #  mac_build_on_commit:
 #    machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,41 +52,41 @@ jobs:
             CMAKE_ARGS="-DMLX_ENABLE_AWS=ON" \
               python setup.py bdist_wheel
 
-  mac_build_on_commit:
-    machine: true
-    resource_class: ml-explore/m-builder
-    parameters:
-      python_version:
-        type: string
-        default: "3.9"
-      macos_version:
-        type: string
-        default: "14"
-      extra_env:
-        type: string
-        default: ""
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: |
-            eval "$(conda shell.bash hook)"
-            rm -r $CONDA_PREFIX/envs/runner-env
-            conda create -y -n runner-env python=3.9
-            conda activate runner-env
-            pip install --upgrade cmake
-            pip install --upgrade pybind11[global]
-            pip install numpy
-            pip install twine
-      - run:
-          name: Build package
-          command: |
-            eval "$(conda shell.bash hook)"
-            conda activate runner-env
-            DEVELOPER_DIR=$(developer_dir_macos_14) \
-              CMAKE_BUILD_PARALLEL_LEVEL="" \
-              CMAKE_ARGS="-DMLX_ENABLE_AWS=ON" \
-              python setup.py bdist_wheel
+#  mac_build_on_commit:
+#    machine: true
+#    resource_class: ml-explore/m-builder
+#    parameters:
+#      python_version:
+#        type: string
+#        default: "3.9"
+#      macos_version:
+#        type: string
+#        default: "14"
+#      extra_env:
+#        type: string
+#        default: ""
+#    steps:
+#      - checkout
+#      - run:
+#          name: Install dependencies
+#          command: |
+#            eval "$(conda shell.bash hook)"
+#            rm -r $CONDA_PREFIX/envs/runner-env
+#            conda create -y -n runner-env python=3.9
+#            conda activate runner-env
+#            pip install --upgrade cmake
+#            pip install --upgrade pybind11[global]
+#            pip install numpy
+#            pip install twine
+#      - run:
+#          name: Build package
+#          command: |
+#            eval "$(conda shell.bash hook)"
+#            conda activate runner-env
+#            DEVELOPER_DIR=$(developer_dir_macos_14) \
+#              CMAKE_BUILD_PARALLEL_LEVEL="" \
+#              CMAKE_ARGS="-DMLX_ENABLE_AWS=ON" \
+#              python setup.py bdist_wheel
 
   linux_build_wheels:
     parameters:
@@ -114,41 +114,41 @@ jobs:
       - store_artifacts:
           path: wheelhouse/
 
-  mac_build_wheels:
-    machine: true
-    resource_class: ml-explore/m-builder
-    parameters:
-      python_version:
-        type: string
-        default: "3.8"
-      macos_version:
-        type: string
-        default: "14"
-      extra_env:
-        type: string
-        default: "DEV_RELEASE=1"
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: |
-            eval "$(conda shell.bash hook)"
-            rm -r $CONDA_PREFIX/envs/runner-env
-            conda create -y -n runner-env python=<< parameters.python_version >>
-            conda activate runner-env
-            pip install -U pip
-            pip install build
-            pip install delocate
-            DEVELOPER_DIR=$(developer_dir_macos_<< parameters.macos_version >>) \
-              CMAKE_BUILD_PARALLEL_LEVEL="" \
-              CMAKE_ARGS="-DMLX_ENABLE_AWS=ON" \
-              << parameters.extra_env >> \
-              SUPER_BUILD=ON \
-              python -m build --wheel
-            delocate-listdeps dist/*
-            delocate-wheel dist/*
-      - store_artifacts:
-          path: dist/
+#  mac_build_wheels:
+#    machine: true
+#    resource_class: ml-explore/m-builder
+#    parameters:
+#      python_version:
+#        type: string
+#        default: "3.8"
+#      macos_version:
+#        type: string
+#        default: "14"
+#      extra_env:
+#        type: string
+#        default: "DEV_RELEASE=1"
+#    steps:
+#      - checkout
+#      - run:
+#          name: Install dependencies
+#          command: |
+#            eval "$(conda shell.bash hook)"
+#            rm -r $CONDA_PREFIX/envs/runner-env
+#            conda create -y -n runner-env python=<< parameters.python_version >>
+#            conda activate runner-env
+#            pip install -U pip
+#            pip install build
+#            pip install delocate
+#            DEVELOPER_DIR=$(developer_dir_macos_<< parameters.macos_version >>) \
+#              CMAKE_BUILD_PARALLEL_LEVEL="" \
+#              CMAKE_ARGS="-DMLX_ENABLE_AWS=ON" \
+#              << parameters.extra_env >> \
+#              SUPER_BUILD=ON \
+#              python -m build --wheel
+#            delocate-listdeps dist/*
+#            delocate-wheel dist/*
+#      - store_artifacts:
+#          path: dist/
 
 workflows:
   build_on_commit:
@@ -159,7 +159,7 @@ workflows:
         - not: << pipeline.parameters.pypi_release >>
     jobs:
       - linux_build_on_commit
-      - mac_build_on_commit
+      #- mac_build_on_commit
   prb:
     when:
       matches:
@@ -170,8 +170,8 @@ workflows:
           type: approval
       - linux_build_on_commit:
           requires: [ hold ]
-      - mac_build_on_commit:
-          requires: [ hold ]
+      #- mac_build_on_commit:
+      #    requires: [ hold ]
   build_dev_release:
     when:
       and:
@@ -183,12 +183,12 @@ workflows:
             parameters:
               python_version: ["38", "39", "310", "311", "312"]
               extra_env: ["DEV_RELEASE=1"]
-      - mac_build_wheels:
-          matrix:
-            parameters:
-              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-              macos_version: ["13", "14"]
-              extra_env: ["DEV_RELEASE=1"]
+      #- mac_build_wheels:
+      #    matrix:
+      #      parameters:
+      #        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+      #        macos_version: ["13", "14"]
+      #        extra_env: ["DEV_RELEASE=1"]
 
   build_pypi_release:
     when:
@@ -201,9 +201,9 @@ workflows:
             parameters:
               python_version: ["38", "39", "310", "311", "312"]
               extra_env: ["PYPI_RELEASE=1"]
-      - mac_build_wheels:
-          matrix:
-            parameters:
-              python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-              macos_version: ["13", "14"]
-              extra_env: ["PYPI_RELEASE=1"]
+      #- mac_build_wheels:
+      #    matrix:
+      #      parameters:
+      #        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+      #        macos_version: ["13", "14"]
+      #        extra_env: ["PYPI_RELEASE=1"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,41 +122,43 @@ jobs:
       - store_artifacts:
           path: wheelhouse/
 
-#  mac_build_wheels:
-#    machine: true
-#    resource_class: ml-explore/m-builder
-#    parameters:
-#      python_version:
-#        type: string
-#        default: "3.8"
-#      macos_version:
-#        type: string
-#        default: "14"
-#      extra_env:
-#        type: string
-#        default: "DEV_RELEASE=1"
-#    steps:
-#      - checkout
-#      - run:
-#          name: Install dependencies
-#          command: |
-#            eval "$(conda shell.bash hook)"
-#            rm -r $CONDA_PREFIX/envs/runner-env
-#            conda create -y -n runner-env python=<< parameters.python_version >>
-#            conda activate runner-env
-#            pip install -U pip
-#            pip install build
-#            pip install delocate
-#            DEVELOPER_DIR=$(developer_dir_macos_<< parameters.macos_version >>) \
-#              CMAKE_BUILD_PARALLEL_LEVEL="" \
-#              CMAKE_ARGS="-DMLX_ENABLE_AWS=ON" \
-#              << parameters.extra_env >> \
-#              SUPER_BUILD=ON \
-#              python -m build --wheel
-#            delocate-listdeps dist/*
-#            delocate-wheel dist/*
-#      - store_artifacts:
-#          path: dist/
+  mac_build_wheels:
+    macos:
+      xcode: << parameters.xcode_version >>
+    resource_class: macos.m1.medium.gen1
+    parameters:
+      xcode_version:
+        type: string
+        default: "15.0.0"
+      extra_env:
+        type: string
+        default: "DEV_RELEASE=1"
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            brew install python@3.9
+            brew install libsndfile libsamplerate ffmpeg jpeg-turbo zlib bzip2 xz aws-sdk-cpp
+            python3.9 -m venv env
+            source env/bin/activate
+            pip install --upgrade pip
+            pip install --upgrade cmake
+            pip install --upgrade pybind11[global]
+            pip install numpy
+            pip install build
+            pip install delocate
+      - run:
+          name: Build wheel
+          command: |
+            source env/bin/activate
+            SUPER_BUILD=ON \
+              << parameters.extra_env >> \
+              python -m build --wheel
+            delocate-listdeps dist/*
+            delocate-wheel dist/*
+      - store_artifacts:
+          path: dist/
 
 workflows:
   build_on_commit:
@@ -171,6 +173,7 @@ workflows:
       - linux_build_on_commit
       - mac_build_on_commit
       - linux_build_wheels
+      - mac_build_wheels
   prb:
     when:
       matches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
     parameters:
       python_version:
         type: string
-        default: "38"
+        default: "39"
       extra_env:
         type: string
         default: "DEV_RELEASE=1"
@@ -170,6 +170,7 @@ workflows:
     jobs:
       - linux_build_on_commit
       - mac_build_on_commit
+      - linux_build_wheels
   prb:
     when:
       matches:

--- a/mlx/data/Array.cpp
+++ b/mlx/data/Array.cpp
@@ -1,7 +1,6 @@
 // Copyright © 2023 Apple Inc.
 
 #include <cstring>
-#include <iostream>
 #include <memory>
 
 #include "mlx/data/Array.h"

--- a/python/src/wrap.cpp
+++ b/python/src/wrap.cpp
@@ -161,10 +161,25 @@ std::shared_ptr<mlx::data::Array> to_array(py::handle obj) {
     return to_array(obj.cast<py::buffer>());
   }
 
+  // Check for python scalars
+  if (py::isinstance<py::int_>(obj)) {
+    return std::make_shared<mlx::data::Array>(obj.cast<int64_t>());
+  }
+  if (py::isinstance<py::float_>(obj)) {
+    return std::make_shared<mlx::data::Array>(obj.cast<double>());
+  }
+
+  // Special case error for string
+  if (py::isinstance<py::str>(obj)) {
+    throw std::invalid_argument(
+        "[to_array] Cannot convert strings to arrays. Please encode them as bytes first.");
+  }
+
+  auto objtype = py::type::of(obj);
   std::ostringstream msg;
   msg << "[to_array] Cannot convert type "
-      << py::type::of(obj).attr("__repr__")().cast<std::string>()
-      << " to an array. Use a numpy array or a python buffer.";
+      << py::str(objtype).cast<std::string>()
+      << " to an array. Use a numpy array, a python buffer or scalar.";
   throw std::invalid_argument(msg.str());
 }
 

--- a/python/src/wrap.cpp
+++ b/python/src/wrap.cpp
@@ -1,5 +1,7 @@
 // Copyright © 2023 Apple Inc.
 
+#include <sstream>
+
 #include "wrap.h"
 
 #include "mlx/data/Dataset.h"
@@ -36,13 +38,70 @@ void init_mlx_data_ops_image(py::module&);
 namespace mlx {
 namespace pybind {
 
+std::shared_ptr<mlx::data::Array> to_array(py::buffer a) {
+  auto is_contiguous = [](const py::buffer_info& info) {
+    bool contiguous =
+        info.ndim > 0 && info.strides[info.ndim - 1] == info.itemsize;
+    for (int i = 0; i < info.ndim - 1; i++) {
+      contiguous &= info.shape[i + 1] * info.strides[i + 1] == info.strides[i];
+    }
+    return contiguous;
+  };
+
+  py::buffer_info info = a.request();
+  if (!is_contiguous(info)) {
+    throw std::runtime_error(
+        "[to_array] Contiguous buffer expected -- maybe cast to np.array");
+  }
+
+  mlx::data::ArrayType dtype;
+  switch (info.format[0]) {
+    case 'b':
+    case 'S':
+    case 'U':
+      dtype = mlx::data::ArrayType::Int8;
+      break;
+    case 'B':
+      dtype = mlx::data::ArrayType::UInt8;
+      break;
+    case 'i':
+      dtype = mlx::data::ArrayType::Int32;
+      break;
+    case 'l':
+      dtype = mlx::data::ArrayType::Int64;
+      break;
+    case 'd':
+      dtype = mlx::data::ArrayType::Double;
+      break;
+    case 'f':
+      dtype = mlx::data::ArrayType::Float;
+      break;
+    default: {
+      std::ostringstream msg;
+      msg << "[to_array] Unsupported buffer type '" << info.format << "'";
+      throw std::invalid_argument(msg.str());
+    }
+  }
+
+  std::vector<int64_t> shape;
+  shape.reserve(info.ndim);
+  for (auto i : info.shape) {
+    shape.push_back(static_cast<int64_t>(i));
+  }
+  auto nbytes = info.strides[0] * info.shape[0];
+  auto arr = std::make_shared<mlx::data::Array>(dtype, shape);
+  std::memcpy(arr->data(), info.ptr, nbytes);
+
+  return arr;
+}
+
 std::shared_ptr<mlx::data::Array> to_array(py::array a) {
   // make sure "a" is contiguous
   const auto c_contiguous =
       py::detail::npy_api::constants::NPY_ARRAY_C_CONTIGUOUS_;
   if (!(c_contiguous == (a.flags() & c_contiguous))) {
     throw std::runtime_error(
-        "contiguous array expected -- use numpy.ascontiguousarray()");
+        "[to_array] Contiguous array expected -- use numpy.ascontiguousarray()");
   }
   std::vector<int64_t> shape(a.ndim());
   for (int i = 0; i < a.ndim(); i++) {
@@ -82,12 +141,31 @@ std::shared_ptr<mlx::data::Array> to_array(py::array a) {
       return std::make_shared<mlx::data::Array>(
           mlx::data::ArrayType::Int8, shape, data);
 
-    default:
-      throw std::runtime_error(
-          "toArray: NYI (unknown array type: " +
-          std::string(1, a.dtype().char_()) + ")");
+    default: {
+      std::ostringstream msg;
+      msg << "[to_array] Unsupported array type '" << a.dtype().char_() << "'";
+      throw std::invalid_argument(msg.str());
+    }
   }
-  return nullptr;
+}
+
+std::shared_ptr<mlx::data::Array> to_array(py::handle obj) {
+  // A numpy array so we can actually ask for mutable data and avoid a copy
+  if (py::isinstance<py::array>(obj)) {
+    return to_array(obj.cast<py::array>());
+  }
+
+  // A buffer must be copied because the data may not be mutable eg a python
+  // bytes object
+  if (py::isinstance<py::buffer>(obj)) {
+    return to_array(obj.cast<py::buffer>());
+  }
+
+  std::ostringstream msg;
+  msg << "[to_array] Cannot convert type "
+      << py::type::of(obj).attr("__repr__")().cast<std::string>()
+      << " to an array. Use a numpy array or a python buffer.";
+  throw std::invalid_argument(msg.str());
 }
 
 struct PyArrayPayload {
@@ -147,8 +225,7 @@ Sample to_sample(py::dict s) {
   Sample res;
   for (auto& el : s) {
     std::string key = el.first.cast<std::string>();
-    py::array value = el.second.cast<py::array>();
-    res[key] = to_array(value);
+    res[key] = to_array(el.second);
   }
   return res;
 }

--- a/python/tests/test_buffer.py
+++ b/python/tests/test_buffer.py
@@ -2,8 +2,6 @@
 
 from unittest import TestCase
 
-import pytest
-
 import mlx.data as dx
 
 

--- a/python/tests/test_buffer.py
+++ b/python/tests/test_buffer.py
@@ -1,11 +1,14 @@
 # Copyright © 2024 Apple Inc.
 
-from unittest import TestCase
+import array
+import unittest
+
+import numpy as np
 
 import mlx.data as dx
 
 
-class TestBuffer(TestCase):
+class TestBuffer(unittest.TestCase):
     def test__getitem__(self):
         n = 5
         b = dx.buffer_from_vector(list(dict(i=i) for i in range(n)))
@@ -38,3 +41,43 @@ class TestBuffer(TestCase):
         stream = buffer.ordered_prefetch(prefetch_size, num_threads)
         for i, e in enumerate(stream):
             self.assertEqual(i, e["i"])
+
+    def test_passing_python_objects(self):
+        with self.assertRaises(ValueError):
+            b = dx.buffer_from_vector([{"a": "hello"}])
+        with self.assertRaises(ValueError):
+            b = dx.buffer_from_vector([{"a": object()}])
+        with self.assertRaises(ValueError):
+            b = dx.buffer_from_vector([{"a": list()}])
+
+        x = array.array("f")
+        x.append(10)
+        x.append(-2.5)
+        y = np.random.randn(10)
+        b = dx.buffer_from_vector(
+            [
+                {
+                    "a": 1,
+                    "b": 1.2,
+                    "c": b"Hello world",
+                    "d": y,
+                    "e": x,
+                }
+            ]
+        )
+        self.assertEqual(-2.5, b[0]["e"][1])
+        self.assertEqual(1, b[0]["a"])
+        self.assertTrue(np.all(y == b[0]["d"]))
+        self.assertTrue(np.all(x == b[0]["e"]))
+
+        # Check that we take np arrays without a copy
+        y[0] = 0
+        self.assertTrue(np.all(y == b[0]["d"]))
+
+        # and buffers via copy
+        x[0] = 0
+        self.assertEqual(10, b[0]["e"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_buffer.py
+++ b/python/tests/test_buffer.py
@@ -47,8 +47,6 @@ class TestBuffer(unittest.TestCase):
             b = dx.buffer_from_vector([{"a": "hello"}])
         with self.assertRaises(ValueError):
             b = dx.buffer_from_vector([{"a": object()}])
-        with self.assertRaises(ValueError):
-            b = dx.buffer_from_vector([{"a": list()}])
 
         x = array.array("f")
         x.append(10)

--- a/super/CMakeLists.txt
+++ b/super/CMakeLists.txt
@@ -28,7 +28,8 @@ ExternalProject_Add(
   pkg-config
   URL http://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz
       http://fresh-center.net/linux/misc/pkg-config-0.29.2.tar.gz
-  CONFIGURE_COMMAND ./configure --prefix=${CMAKE_BINARY_DIR}/deps
+  CONFIGURE_COMMAND CFLAGS=-Wno-int-conversion CXXFLAGS=-Wno-int-conversion
+                    ./configure --prefix=${CMAKE_BINARY_DIR}/deps
                     --disable-shared --with-internal-glib
   BUILD_COMMAND make
   INSTALL_COMMAND make install
@@ -48,7 +49,7 @@ ExternalProject_Add(
 
 ExternalProject_Add(
   zlib
-  URL https://www.zlib.net/zlib-1.3.tar.gz
+  URL https://www.zlib.net/zlib-1.3.1.tar.gz
   CONFIGURE_COMMAND PATH=${PATH} PKG_CONFIG_PATH=${PKG_CONFIG_PATH} CFLAGS=-fPIC
                     ./configure --prefix=${CMAKE_BINARY_DIR}/deps --static
   BUILD_COMMAND make


### PR DESCRIPTION
Update our CI so it will actually build and run the minimal tests we have. In addition this
- Fixes the super build on the Mac and Linux (minor changes)
- Changes the way we cast to `Array`. Previously everything was cast to numpy and then made into an `Array` without copy. Basically, we relied on numpy to do the copy. We now
  - copy buffers ourselves
  - cast scalars directly
  - refuse to cast strings if they are not converted to bytes
  - delegate to numpy to handle the array interface which means we still get no copy arrays from PyTorch for instance