### PR TITLE
Fix typo in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
             auditwheel repair dist/*
       - when:
           condition:
-            equal: [ << parameters.build_env >>, "PYPI_RELEASE=1" ]
+            equal: [ << parameters.extra_env >>, "PYPI_RELEASE=1" ]
           steps:
             - run:
                 name: Upload package
@@ -168,7 +168,7 @@ jobs:
             delocate-wheel dist/*
       - when:
           condition:
-            equal: [ << parameters.build_env >>, "PYPI_RELEASE=1" ]
+            equal: [ << parameters.extra_env >>, "PYPI_RELEASE=1" ]
           steps:
             - run:
                 name: Upload package


### PR DESCRIPTION
Fix typo in build-release jobs in CI. They weren't checked before because they can only run on the main branch.