### PR TITLE
fix(core): Include algorithm library in Graph

### DIFF
--- a/mlx/data/core/Graph.cpp
+++ b/mlx/data/core/Graph.cpp
@@ -1,5 +1,6 @@
 // Copyright © 2023 Apple Inc.
 
+#include <algorithm>
 #include <limits>
 #include <queue>
 #include <sstream>


### PR DESCRIPTION
While trying to build `mlx-data` from source using Linux containers (e.g. `debian:trixie`), I noticed that compiler complains that `reverse_copy` is not a member of `std`.

This issue can be fixed by including the `<algorithm>` header in Graph.cpp.


```
[11%] Building CXX object CMakeFiles/mlxdata.dir/mlx/data/core/Graph.cpp.o
#36 10.59 /home/mpiuser/mlx-data/mlx/data/core/Graph.cpp: In member function 'std::tuple<std::vector<long int, std::allocator<long int> >, std::vector<long int, std::allocator<long int> > > mlx::data::core::ShortestPath::find(double*)':
#36 10.59 /home/mpiuser/mlx-data/mlx/data/core/Graph.cpp:228:14: error: 'reverse_copy' is not a member of 'std'
#36 10.59   228 |         std::reverse_copy(
#36 10.59       |              ^~~~~~~~~~~~
#36 10.59 /home/mpiuser/mlx-data/mlx/data/core/Graph.cpp:233:14: error: 'reverse_copy' is not a member of 'std'
#36 10.59   233 |         std::reverse_copy(
#36 10.59       |              ^~~~~~~~~~~~
#36 10.65 gmake[2]: *** [CMakeFiles/mlxdata.dir/build.make:191: CMakeFiles/mlxdata.dir/mlx/data/core/Graph.cpp.o] Error 1
#36 10.65 gmake[1]: *** [CMakeFiles/Makefile2:112: CMakeFiles/mlxdata.dir/all] Error 2
```

cc @awni 
