### PR TITLE
fix(datasets): Fix contiguous buffer in load MNIST dataset

### DIFF
--- a/python/mlx/data/datasets/mnist.py
+++ b/python/mlx/data/datasets/mnist.py
@@ -40,19 +40,29 @@ def _load_mnist_wrapper(root=None, train=True, dataset="mnist"):
         for out_file, key, _ in filename[:2]:
             with gzip.open(out_file.name, "rb") as f:
                 mnist[key] = np.frombuffer(f.read(), np.uint8, offset=16).reshape(
-                    -1, 28, 28, 1
+                    -1, 28 * 28
                 )
         for out_file, key, _ in filename[-2:]:
             with gzip.open(out_file.name, "rb") as f:
                 mnist[key] = np.frombuffer(f.read(), np.uint8, offset=8)
-        train_set = [
-            {"image": mnist["training_images"][i], "label": mnist["training_labels"][i]}
-            for i in range(len(mnist["training_images"]))
-        ]
-        test_set = [
-            {"image": mnist["test_images"][i], "label": mnist["test_labels"][i]}
-            for i in range(len(mnist["test_images"]))
-        ]
+
+        train_set = []
+        for i in range(len(mnist["training_images"])):
+            train_set.append(
+                {
+                    "image": np.ascontiguousarray(mnist["training_images"][i]),
+                    "label": mnist["training_labels"][i].item(),
+                }
+            )
+
+        test_set = []
+        for i in range(len(mnist["test_images"])):
+            test_set.append(
+                {
+                    "image": np.ascontiguousarray(mnist["test_images"][i]),
+                    "label": mnist["test_labels"][i].item(),
+                }
+            )
 
         with (root / "train.pkl").open("wb") as f:
             pickle.dump(train_set, f)


### PR DESCRIPTION
This should fix this error when using the `load_mnist()` dataset:

```
    return dx.buffer_from_vector(pickle.load(f))
           ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
RuntimeError: [to_array] Contiguous buffer expected -- maybe cast to np.array
```
Additionally, I correctly re-shape an MNIST image, [like here.](https://github.com/ml-explore/mlx-examples/blob/main/mnist/mnist.py#L42)


I have [a working example](https://github.com/kubeflow/trainer/blob/7dbb2311cbe2b5c7949ec6be8804d92378c77201/examples/mlx/image-classification/MLX-Distributed-Mnist.ipynb) using this API for distributed MNIST training here: https://github.com/kubeflow/trainer/pull/2565
If you're happy with the changes, I can update the [MNIST example](https://github.com/ml-explore/mlx-examples/tree/main/mnist) to support distributed training and re-use MLX Data API:
```py
from mlx.data.datasets import load_mnist
```


/assign @angeloskath @awni 