### PR TITLE
Update __init__.py

### DIFF
--- a/python/mlx/data/__init__.py
+++ b/python/mlx/data/__init__.py
@@ -19,7 +19,6 @@ except AttributeError:
 
 del numpy
 
-from . import tokenizer_helpers
+from . import datasets, tokenizer_helpers
 from ._c import *
 from ._c import __version__
-from . import datasets

--- a/python/mlx/data/__init__.py
+++ b/python/mlx/data/__init__.py
@@ -22,3 +22,4 @@ del numpy
 from . import tokenizer_helpers
 from ._c import *
 from ._c import __version__
+from . import datasets


### PR DESCRIPTION
Issue:

Users attempting to access mlx.data.datasets encounter an AttributeError: module 'mlx.data' has no attribute 'datasets'. This occurs because the datasets submodule, while present in the mlx/data/ directory, is not explicitly imported into the mlx.data package's namespace via its __init__.py file.

Root Cause:

The mlx/data/__init__.py file was missing the necessary import statement to make the datasets submodule available as an attribute of the mlx.data package. Without from . import datasets, Python cannot resolve mlx.data.datasets.

Solution:

This PR resolves the issue by adding the line from . import datasets to the mlx/data/__init__.py file. This explicitly imports the datasets submodule, making it accessible as mlx.data.datasets as intended and expected by users.